### PR TITLE
cmake: use COMMON_OPTS variable for compiler flags

### DIFF
--- a/ast/CMakeLists.txt
+++ b/ast/CMakeLists.txt
@@ -26,5 +26,7 @@ add_executable(${PROJECT_NAME}-test
 target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/../util/build/libsd-util.a)
 target_link_libraries(${PROJECT_NAME}-test ${CMAKE_SOURCE_DIR}/../util/build/libsd-util.a)
 
-target_compile_options(${PROJECT_NAME}      PUBLIC "-g" "-march=native" "-Wall" "-Werror")
-target_compile_options(${PROJECT_NAME}-test PUBLIC "-g" "-march=native" "-Wall" "-Werror")
+set(COMMON_OPTS, "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+
+target_compile_options(${PROJECT_NAME}      PUBLIC ${COMMON_OPTS})
+target_compile_options(${PROJECT_NAME}-test PUBLIC ${COMMON_OPTS})

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -184,9 +184,11 @@ add_executable("sd-tests"
 	test/gen_tac/test_gen_tac_structdecl.c
 )
 
-target_compile_options("sd-base"  PUBLIC "-g" "-march=native" "-Wall" "-Wextra")
-target_compile_options("sd"       PUBLIC "-g" "-march=native" "-Wall" "-Wextra")
-target_compile_options("sd-tests" PUBLIC "-g" "-march=native" "-Wall" "-Wextra")
+set(COMMON_OPTS, "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+
+target_compile_options("sd-base"  PUBLIC ${COMMON_OPTS})
+target_compile_options("sd"       PUBLIC ${COMMON_OPTS})
+target_compile_options("sd-tests" PUBLIC ${COMMON_OPTS})
 
 #tables dependency
 target_link_libraries("sd-base" ${CMAKE_SOURCE_DIR}/../tables/build/libsd-tables.a)

--- a/compiler/main/avr_code_gen/compile_ir/compile_tac_store_local.c
+++ b/compiler/main/avr_code_gen/compile_ir/compile_tac_store_local.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <assert.h>
 

--- a/compiler/test/avr_code_gen/timer/test_avr_code_gen_timer.c
+++ b/compiler/test/avr_code_gen/timer/test_avr_code_gen_timer.c
@@ -5,6 +5,8 @@
 #include "libvmcu/libvmcu_system.h"
 #include "libvmcu/libvmcu_analyzer.h"
 
+#include "compiler/test/libvmcu_utils/libvmcu_utils.h"
+
 #include "avr_code_gen/cg_avr.h"
 #include "avr_code_gen/cg_avr_basic_block.h"
 

--- a/ibuffer/CMakeLists.txt
+++ b/ibuffer/CMakeLists.txt
@@ -13,4 +13,6 @@ add_library(${PROJECT_NAME} STATIC
 #Util dependency
 target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/../util/build/libsd-util.a)
 
-target_compile_options(${PROJECT_NAME} PUBLIC "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+set(COMMON_OPTS, "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+
+target_compile_options(${PROJECT_NAME} PUBLIC ${COMMON_OPTS})

--- a/lexer/CMakeLists.txt
+++ b/lexer/CMakeLists.txt
@@ -27,14 +27,28 @@ add_executable(dragon-lexer-tests
 	test/testcases/tests_other.c
 )
 
+# Add the executable for dragon-lexer without lex.yy.c
 add_executable(dragon-lexer
-	src/driver.c
-	src/main.c
-	lex.yy.c
+    src/driver.c
+    src/main.c
 )
 
-target_compile_options(dragon-lexer       PUBLIC "-g" "-march=native" "-Wall" "-Wextra" "--std=c11" "-lfl")
-target_compile_options(dragon-lexer-tests PUBLIC "-g" "-march=native" "-Wall" "-Wextra" "--std=c11")
+# Add a separate target for lex.yy.c
+add_library(lexer-lib STATIC lex.yy.c)
+
+set(MINIMAL_OPTS, "-g" "-march=native" "--std=c11")
+set(COMMON_OPTS, "-Wall" "-Wextra" "-Werror")
+
+# Apply minimal compile options for lex.yy.c
+target_compile_options(lexer-lib PRIVATE ${MINIMAL_OPTS} "-Wno-implicit-function-declaration")
+
+# Link lexer-lib to the main executable
+target_link_libraries(dragon-lexer lexer-lib)
+
+# Apply compile options for dragon-lexer
+target_compile_options(dragon-lexer PUBLIC ${COMMON_OPTS} "-lfl")
+
+target_compile_options(dragon-lexer-tests PUBLIC ${COMMON_OPTS})
 
 #target_link_libraries(dragon-lexer ${FLEX_LIBRARIES})
 #https://askubuntu.com/questions/289547/where-are-flex-libraries-located

--- a/lexer/test/lexer_test_utils.c
+++ b/lexer/test/lexer_test_utils.c
@@ -6,6 +6,7 @@
 #include "lexer_test_utils.h"
 
 #include "../../token/reader/token_reader.h"
+#include "../../token/token/token.h"
 #include "../../token/list/TokenList.h"
 
 struct Token** lex(char* source) {

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -111,9 +111,11 @@ add_executable(dragon-parser
 	main/commandline/parser_help.c
 )
 
-target_compile_options(dragon-parser PUBLIC "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
-target_compile_options(dragon-parser-base PUBLIC "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
-target_compile_options(dragon-parser-tests PUBLIC "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+set(COMMON_OPTS, "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+
+target_compile_options(dragon-parser PUBLIC ${COMMON_OPTS})
+target_compile_options(dragon-parser-base PUBLIC ${COMMON_OPTS})
+target_compile_options(dragon-parser-tests PUBLIC ${COMMON_OPTS})
 
 #Util dependency
 target_link_libraries(dragon-parser-base ${CMAKE_SOURCE_DIR}/../util/build/libsd-util.a)

--- a/rat/CMakeLists.txt
+++ b/rat/CMakeLists.txt
@@ -18,5 +18,7 @@ add_executable("sd-rat-tests"
 target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/../util/build/libsd-util.a)
 target_link_libraries("sd-rat-tests" ${CMAKE_SOURCE_DIR}/../util/build/libsd-util.a)
 
-target_compile_options(${PROJECT_NAME} PUBLIC "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
-target_compile_options("sd-rat-tests" PUBLIC "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+set(COMMON_OPTS, "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+
+target_compile_options(${PROJECT_NAME} PUBLIC ${COMMON_OPTS})
+target_compile_options("sd-rat-tests" PUBLIC ${COMMON_OPTS})

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -20,7 +20,9 @@ add_library(${PROJECT_NAME} STATIC
         symtable/symtable.c
 )
 
-target_compile_options(${PROJECT_NAME} PUBLIC "-g" "-march=native" "-Wall" "-Werror")
+set(COMMON_OPTS, "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+
+target_compile_options(${PROJECT_NAME} PUBLIC ${COMMON_OPTS})
 
 target_include_directories(${PROJECT_NAME} PUBLIC "..")
 

--- a/tac/CMakeLists.txt
+++ b/tac/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(${PROJECT_NAME} STATIC
         tacbuffer.c
 )
 
-target_compile_options(${PROJECT_NAME} PUBLIC "-g" "-march=native" "-Wall" "-Werror")
+set(COMMON_OPTS, "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+
+target_compile_options(${PROJECT_NAME} PUBLIC ${COMMON_OPTS})
 
 target_include_directories(${PROJECT_NAME} PUBLIC "..")

--- a/token/CMakeLists.txt
+++ b/token/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(${PROJECT_NAME} STATIC
 #Util dependency
 target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/../util/build/libsd-util.a)
 
-target_compile_options(${PROJECT_NAME} PUBLIC "-g" "-march=native" "-Wall" )
+set(COMMON_OPTS, "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+
+target_compile_options(${PROJECT_NAME} PUBLIC ${COMMON_OPTS})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ".")

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -8,4 +8,6 @@ add_library(${PROJECT_NAME} STATIC
 	exit_malloc/exit_malloc.c
 )
 
-target_compile_options(${PROJECT_NAME} PUBLIC "-g" "-march=native" "-Wall" "-Werror")
+set(COMMON_OPTS, "-g" "-march=native" "-Wall" "-Wextra" "-Werror")
+
+target_compile_options(${PROJECT_NAME} PUBLIC ${COMMON_OPTS})


### PR DESCRIPTION
Consolidated the compiler flags into this variable.

This makes the CMakeLists.txt easier to read.

Also added -Werror.