### PR TITLE
ci: enable valgrind checks for some tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ jobs:
             echo 'export PATH=/home/circleci/project/build/lexer/:/home/circleci/project/build/parser:/home/circleci/project/build/compiler:"$PATH"' >> "$BASH_ENV"
             source "$BASH_ENV"
             make test
+      - run:
+          name: "ci valgrind tests"
+          command: |
+            make ci_valgrind_tests
   build-job-ubuntu-2204:
     machine:
       image: ubuntu-2204:2022.10.2
@@ -47,6 +51,10 @@ jobs:
             echo 'export PATH=/home/circleci/project/build/lexer/:/home/circleci/project/build/parser:/home/circleci/project/build/compiler:"$PATH"' >> "$BASH_ENV"
             source "$BASH_ENV"
             make test
+      - run:
+          name: "ci valgrind tests"
+          command: |
+            make ci_valgrind_tests
   check-format:
     docker:
       - image: library/archlinux:latest

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,22 @@ TESTS=build/ast/sd-ast-test \
       build/parser/dragon-parser-tests \
       build/compiler/sd-tests \
 
+VALGRIND_OPTS=--leak-check=full --show-leak-kinds=all --track-origins=yes --error-exitcode=1
+
+ci_valgrind_tests: ${TESTS}
+	export CI_DIR=/home/circleci/project
+	export BUILD_DIR=${CI_DIR}/build
+	export PATH=${BUILD_DIR}/lexer/:${BUILD_DIR}/parser:${BUILD_DIR}/compiler:${PATH}
+	make valgrind_tests
+
+valgrind_tests: ${TESTS}
+	valgrind ${VALGRIND_OPTS} ./build/ast/sd-ast-test && \
+	valgrind ${VALGRIND_OPTS} ./build/rat/sd-rat-tests && \
+	valgrind ${VALGRIND_OPTS} ./build/lexer/dragon-lexer-tests
+
+	# TODO: enable the below. right now it has still too many memory leaks
+	#valgrind ${VALGRIND_OPTS} ./build/parser/dragon-parser-tests
+
 clean_cmake:
 	rm -rf CMakeFiles
 	rm -rf build

--- a/ast/test/test_str_ast.c
+++ b/ast/test/test_str_ast.c
@@ -106,7 +106,7 @@ void test_str_expr() {
 
 	assert(strcmp(s, "-45*-45") == 0);
 
-	free(u2);
+	free_un_op_term(u2);
 	free(s);
 }
 void test_str_op() {

--- a/lexer/test/testcases/tests_other.c
+++ b/lexer/test/testcases/tests_other.c
@@ -197,14 +197,16 @@ void test_typeidentifier_primitive() {
 	    TYPEID_PRIMITIVE_INT16,
 	    TYPEID_PRIMITIVE_UINT16,
 	};
-	char* expect[] = {"int", "uint", "int8", "uint8", "int16", "uint16"};
 
-	for (int i = 0; i < 6; i++) {
+	char* expect[] = {"int", "uint", "int8", "uint8", "int16", "uint16"};
+	size_t expect_count = 6;
+
+	for (int i = 0; i < expect_count; i++) {
 		assert(tokens[i]->kind == expect_kind[i]);
 		assert(strcmp(tokens[i]->value_ptr, expect[i]) == 0);
 	}
 
-	free_tokens(tokens, 4);
+	free_tokens(tokens, expect_count);
 
 	//------------------------------
 	char* str2 = "char bool ";


### PR DESCRIPTION
Run some tests with valgrind additionally.
This will be after they already ran successfully.

By covering the tests, the project itself will be covered indirectly.