### PR TITLE
token: encapsulate struct TokenList

### DIFF
--- a/parser/main/astnodes/Namespace.c
+++ b/parser/main/astnodes/Namespace.c
@@ -35,10 +35,10 @@ struct Namespace* makeNamespace(struct TokenList* tokens, char* name) {
 	res->structs = exit_malloc(sizeof(struct StructDecl*) * res->capacity_structs);
 
 	res->src_path = exit_malloc(sizeof(char) * (strlen(name) + 3 + 1));
-	res->token_path = exit_malloc(sizeof(char) * (strlen(tokens->rel_path) + 1));
+	res->token_path = exit_malloc(sizeof(char) * (strlen(list_rel_path(tokens)) + 1));
 
 	sprintf(res->src_path, "%s.dg", name);
-	strcpy(res->token_path, tokens->rel_path);
+	strcpy(res->token_path, list_rel_path(tokens));
 	strncpy(res->name, name, DEFAULT_STR_SIZE);
 
 	struct TokenList* copy = list_copy(tokens);

--- a/token/list/TokenList.c
+++ b/token/list/TokenList.c
@@ -7,6 +7,29 @@
 #include "../token/token.h"
 #include "../../util/exit_malloc/exit_malloc.h"
 
+struct TokenList {
+	//relative path of the source file
+	char* rel_path;
+
+	//all the tokens, including those
+	//already consumed
+	struct Token** tokens; //private
+	//how many pointers we can store
+	//with the currently allocated memory
+	uint16_t capacity; //private
+
+	//the index of the first token that was
+	//not already consumed
+	uint16_t index_head;
+
+	//the amount of tokens stored,
+	//even if they have already been consumed
+	uint16_t tokens_stored;
+
+	//token count
+	uint16_t tokensc; //private
+};
+
 struct TokenList* makeTokenList2(char* filename) {
 
 	const int initial_size = 20;
@@ -177,6 +200,10 @@ void list_print(struct TokenList* list) {
 	char* str = list_code(list);
 	printf("%s\n", str);
 	free(str);
+}
+
+char* list_rel_path(struct TokenList* list) {
+	return list->rel_path;
 }
 
 void freeTokenList(struct TokenList* list) {

--- a/token/list/TokenList.h
+++ b/token/list/TokenList.h
@@ -1,34 +1,11 @@
 #ifndef TOKENLIST
 #define TOKENLIST
 
-#include <string.h>
 #include <stdbool.h>
 #include <inttypes.h>
 
 struct Token;
-
-struct TokenList {
-	//relative path of the source file
-	char* rel_path;
-
-	//all the tokens, including those
-	//already consumed
-	struct Token** tokens; //private
-	//how many pointers we can store
-	//with the currently allocated memory
-	uint16_t capacity; //private
-
-	//the index of the first token that was
-	//not already consumed
-	uint16_t index_head;
-
-	//the amount of tokens stored,
-	//even if they have already been consumed
-	uint16_t tokens_stored;
-
-	//token count
-	uint16_t tokensc; //private
-};
+struct TokenList;
 
 struct TokenList* makeTokenList();
 struct TokenList* makeTokenList2(char* filename);
@@ -55,6 +32,8 @@ int list_size(struct TokenList* list);
 char* list_code(struct TokenList* list);
 
 void list_print(struct TokenList* list);
+
+char* list_rel_path(struct TokenList* list);
 
 void freeTokenList(struct TokenList* list);
 void freeTokenListShallow(struct TokenList* list);


### PR DESCRIPTION
The definition of struct TokenList can be opaque for better encapsulation.