### PR TITLE
test: compiler: flag to print testcase duration

### DIFF
--- a/compiler/test/avr_code_gen/test_avr_code_gen.c
+++ b/compiler/test/avr_code_gen/test_avr_code_gen.c
@@ -20,34 +20,3 @@
 void status_test_codegen(char* msg) {
 	printf(" - [TEST] avr codegen %s\n", msg);
 }
-
-void test_suite_avr_code_gen() {
-
-	test_compile_tac_setup_sp();
-
-	test_compile_tac_nop();
-	test_compile_tac_const_value();
-
-	test_compile_tac_store_const_addr();
-	test_compile_tac_load_const_addr();
-
-	test_compile_tac_binary_op_immediate();
-	test_compile_tac_unary_op();
-	test_compile_tac_binary_op();
-
-	test_compile_tac_goto();
-	test_compile_tac_if_goto();
-	test_compile_tac_if_cmp_goto();
-
-	test_compile_tac_return();
-	test_compile_tac_copy();
-	test_compile_tac_param();
-	test_compile_tac_call();
-	test_compile_tac_setup_stackframe();
-
-	test_compile_tac_load();
-	test_compile_tac_store();
-
-	//test AVR Codegen as it relates to internal timers
-	test_avr_code_gen_timer();
-}

--- a/compiler/test/avr_code_gen/test_avr_code_gen.h
+++ b/compiler/test/avr_code_gen/test_avr_code_gen.h
@@ -1,6 +1,6 @@
-#ifndef SMALLDRAGON_TOPLEVEL_TEST_AVR_CODE_GEN_H
-#define SMALLDRAGON_TOPLEVEL_TEST_AVR_CODE_GEN_H
+#pragma once
 
-void test_suite_avr_code_gen();
+#include "compile_ir/test_compile_tac.h"
+#include "timer/test_avr_code_gen_timer.h"
+
 void status_test_codegen(char* msg);
-#endif

--- a/compiler/test/gen_tac/test_gen_tac.c
+++ b/compiler/test/gen_tac/test_gen_tac.c
@@ -3,24 +3,6 @@
 
 #include "test_gen_tac.h"
 
-void test_suite_tac_codegen() {
-
-	test_gen_tac_mdirect();
-	test_gen_tac_assignstmt();
-	test_gen_tac_massignstmt();
-	test_gen_tac_expr();
-
-	test_gen_tac_ifstmt();
-	test_gen_tac_whilestmt();
-	test_gen_tac_forstmt();
-
-	test_gen_tac_simplevar();
-	test_gen_tac_variable();
-
-	test_gen_tac_call();
-	test_gen_tac_structdecl();
-}
-
 void status_test_codegen_tac(char* msg) {
 	printf(" - [TEST] TAC CodeGen %s\n", msg);
 }

--- a/compiler/test/gen_tac/test_gen_tac.h
+++ b/compiler/test/gen_tac/test_gen_tac.h
@@ -1,12 +1,9 @@
+#pragma once
+
 #include "libvmcu/libvmcu_system.h"
 #include "libvmcu/libvmcu_analyzer.h"
 
 #include "libvmcu_utils/libvmcu_utils.h"
-
-#ifndef TEST_GEN_TAC_H
-#define TEST_GEN_TAC_H
-
-void test_suite_tac_codegen();
 
 void test_gen_tac_assignstmt();
 void test_gen_tac_massignstmt();
@@ -23,5 +20,3 @@ void test_gen_tac_structdecl();
 void status_test_codegen_tac(char* msg);
 
 vmcu_system_t* prepare_vmcu_system_from_code_snippet(char* code_snippet);
-
-#endif

--- a/compiler/test/test.c
+++ b/compiler/test/test.c
@@ -1,7 +1,9 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <time.h>
+#include <string.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 #include "typechecker/test_typechecker.h"
 #include "typeinference/test_typeinference.h"
@@ -13,24 +15,109 @@ static void status_test_transpiler(char* msg) {
 	printf("[Compiler][TEST-SUITE] %s\n", msg);
 }
 
-int main() {
+struct sd_test_flags {
+	bool testcase_duration;
+};
+
+static void parse_flags(int argc, char* argv[], struct sd_test_flags* flags) {
+
+	flags->testcase_duration = false;
+
+	for (int i = 1; i < argc; i++) {
+		char* flag = argv[i];
+
+		if (strcmp(flag, "--testcase-duration") == 0) {
+			flags->testcase_duration = true;
+		}
+	}
+}
+
+#include "testcases.c"
+
+struct testsuite {
+	char* name;
+	void (**testcases)();
+};
+
+struct testsuite testsuites[] = {
+    {
+	.name = "Typeinference",
+	.testcases = tests_typeinference,
+    },
+    {
+	.name = "Typechecker",
+	.testcases = tests_typechecker,
+    },
+    {
+	.name = "AVR CodeGen",
+	.testcases = tests_avr_codegen,
+    },
+    {
+	.name = "TAC CodeGen from Snippets",
+	.testcases = tests_tac_codegen,
+    },
+    {
+	.name = "x86 CodeGen",
+	.testcases = tests_x86_codegen,
+    },
+    {
+	.name = NULL,
+    }};
+
+static void run_testcase(void (*testcase)(), struct sd_test_flags* flags) {
+
+	struct timeval start, stop;
+
+	gettimeofday(&start, NULL);
+	testcase();
+	gettimeofday(&stop, NULL);
+
+	long elapsed_ms = (stop.tv_sec - start.tv_sec) * 1000.0;
+	elapsed_ms += (stop.tv_usec - start.tv_usec) / 1000.0;
+
+	if (flags->testcase_duration) {
+		printf("   took %4ld ms\n", elapsed_ms);
+	}
+}
+
+static void run_testsuite(struct testsuite* suite, struct sd_test_flags* flags) {
+
+	status_test_transpiler(suite->name);
+
+	for (int i = 0; suite->testcases[i] != NULL; i++) {
+		run_testcase(suite->testcases[i], flags);
+	}
+}
+
+void run_testsuites(struct sd_test_flags* flags) {
+
+	for (int suitei = 0; testsuites[suitei].name != NULL; suitei++) {
+
+		run_testsuite(&testsuites[suitei], flags);
+	}
+}
+
+int main(int argc, char* argv[]) {
+
+	struct sd_test_flags flags;
+	struct timeval start, stop;
+
+	parse_flags(argc, argv, &flags);
 
 	status_test_transpiler("Running tests for smalldragon/compiler:");
 
-	status_test_transpiler("Typeinference");
-	test_suite_typeinference();
+	gettimeofday(&start, NULL);
 
-	status_test_transpiler("Typechecker");
-	test_suite_typechecker();
+	run_testsuites(&flags);
 
-	status_test_transpiler("AVR CodeGen");
-	test_suite_avr_code_gen();
+	gettimeofday(&stop, NULL);
 
-	status_test_transpiler("TAC CodeGen from Snippets");
-	test_suite_tac_codegen();
+	long elapsed_ms = (stop.tv_sec - start.tv_sec) * 1000.0;
+	elapsed_ms += (stop.tv_usec - start.tv_usec) / 1000.0;
 
-	status_test_transpiler("x86 CodeGen");
-	test_suite_x86_code_gen();
+	if (flags.testcase_duration) {
+		printf("\n[TOTAL DURATION] %4ld ms\n", elapsed_ms);
+	}
 
 	status_test_transpiler("PASSED ALL TESTS\n");
 

--- a/compiler/test/testcases.c
+++ b/compiler/test/testcases.c
@@ -1,0 +1,126 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "typechecker/test_typechecker.h"
+#include "typeinference/test_typeinference.h"
+#include "avr_code_gen/test_avr_code_gen.h"
+#include "x86_code_gen/test_x86_code_gen.h"
+#include "gen_tac/test_gen_tac.h"
+
+void (*tests_typeinference[])() = {
+    test_infer_type_term,
+    test_infer_type_unopterm,
+    test_infer_type_expr,
+    test_infer_type_expr_multiple_terms,
+    test_infer_type_return_type_subroutine,
+    test_infer_type_call_with_struct_member_access,
+    test_infer_type_call_with_array_access,
+    test_infer_type_simplevar_no_indices,
+    test_infer_type_simplevar_with_indices,
+    test_infer_type_var_with_member_access,
+    test_infer_type_type_param,
+    NULL,
+};
+
+void (*tests_typechecker[])() = {
+    test_typecheck_wrong_assign_primitive,
+    test_typecheck_wrong_number_of_args,
+    test_typecheck_wrong_type_of_arg,
+    test_typecheck_wrong_return_type,
+    test_typecheck_binop_type_mismatch,
+    test_typecheck_subr_not_found,
+    test_typecheck_impure_called_in_pure,
+    test_typecheck_condition_requires_bool,
+    test_typecheck_range_requires_int,
+    test_typecheck_wrong_op_unop,
+    test_typecheck_index_not_integer_type,
+    test_typecheck_too_many_indices,
+    test_typecheck_local_var_not_a_subroutine,
+    test_typecheck_var_not_found,
+
+    //one test to trigger all typechecker errors, in sequence,
+    //to iterate on the error messages (better dev experience)
+    //and make sure multiple errors will be found
+    test_typecheck_all_type_errors,
+    NULL,
+};
+
+void (*tests_avr_codegen[])() = {
+    test_compile_tac_setup_sp,
+
+    test_compile_tac_nop,
+    test_compile_tac_const_value,
+
+    test_compile_tac_store_const_addr,
+    test_compile_tac_load_const_addr,
+
+    test_compile_tac_binary_op_immediate,
+    test_compile_tac_unary_op,
+    test_compile_tac_binary_op,
+
+    test_compile_tac_goto,
+    test_compile_tac_if_goto,
+    test_compile_tac_if_cmp_goto,
+
+    test_compile_tac_return,
+    test_compile_tac_copy,
+    test_compile_tac_param,
+    test_compile_tac_call,
+    test_compile_tac_setup_stackframe,
+
+    test_compile_tac_load,
+    test_compile_tac_store,
+
+    //test AVR Codegen as it relates to internal timers
+    test_avr_code_gen_timer,
+    NULL,
+};
+
+void (*tests_tac_codegen[])() = {
+    test_gen_tac_mdirect,
+    test_gen_tac_assignstmt,
+    test_gen_tac_massignstmt,
+    test_gen_tac_expr,
+
+    test_gen_tac_ifstmt,
+    test_gen_tac_whilestmt,
+    test_gen_tac_forstmt,
+
+    test_gen_tac_simplevar,
+    test_gen_tac_variable,
+
+    test_gen_tac_call,
+    test_gen_tac_structdecl,
+    NULL,
+};
+
+void (*tests_x86_codegen[])() = {
+    test_x86_compile_tac_nop,
+    test_x86_compile_tac_const_value,
+
+    test_x86_compile_tac_store_const_addr,
+    test_x86_compile_tac_load_const_addr,
+
+    test_x86_compile_tac_binary_op_immediate,
+    test_x86_compile_tac_unary_op,
+    test_x86_compile_tac_binary_op,
+
+    test_x86_compile_tac_goto,
+    test_x86_compile_tac_if_goto,
+    test_x86_compile_tac_if_cmp_goto,
+
+    test_x86_compile_tac_return,
+    test_x86_compile_tac_copy,
+    test_x86_compile_tac_param,
+    //test_x86_compile_tac_call,
+    //test_x86_compile_tac_setup_stackframe,
+
+    test_x86_compile_tac_load,
+    test_x86_compile_tac_store,
+
+    test_x86_compile_tac_load_local,
+    test_x86_compile_tac_store_local,
+    NULL,
+};

--- a/compiler/test/typechecker/test_typechecker.c
+++ b/compiler/test/typechecker/test_typechecker.c
@@ -7,23 +7,6 @@
 #include "test_typechecker_util.h"
 #include "typechecker/tcctx.h"
 
-static void test_typecheck_wrong_assign_primitive();
-static void test_typecheck_wrong_number_of_args();
-static void test_typecheck_wrong_type_of_arg();
-static void test_typecheck_wrong_return_type();
-static void test_typecheck_binop_type_mismatch();
-static void test_typecheck_subr_not_found();
-static void test_typecheck_impure_called_in_pure();
-static void test_typecheck_condition_requires_bool();
-static void test_typecheck_range_requires_int();
-static void test_typecheck_wrong_op_unop();
-static void test_typecheck_index_not_integer_type();
-static void test_typecheck_too_many_indices();
-static void test_typecheck_local_var_not_a_subroutine();
-static void test_typecheck_var_not_found();
-//------------
-static void test_typecheck_all_type_errors();
-
 static void status_test_typechecker(char* msg) {
 	printf(" - [TEST] %s\n", msg);
 }
@@ -35,30 +18,7 @@ static void free_tc_errors(struct TCError* error) {
 	free(error);
 }
 
-void test_suite_typechecker() {
-
-	test_typecheck_wrong_assign_primitive();
-	test_typecheck_wrong_number_of_args();
-	test_typecheck_wrong_type_of_arg();
-	test_typecheck_wrong_return_type();
-	test_typecheck_binop_type_mismatch();
-	test_typecheck_subr_not_found();
-	test_typecheck_impure_called_in_pure();
-	test_typecheck_condition_requires_bool();
-	test_typecheck_range_requires_int();
-	test_typecheck_wrong_op_unop();
-	test_typecheck_index_not_integer_type();
-	test_typecheck_too_many_indices();
-	test_typecheck_local_var_not_a_subroutine();
-	test_typecheck_var_not_found();
-
-	//one test to trigger all typechecker errors, in sequence,
-	//to iterate on the error messages (better dev experience)
-	//and make sure multiple errors will be found
-	test_typecheck_all_type_errors();
-}
-
-static void test_typecheck_wrong_assign_primitive() {
+void test_typecheck_wrong_assign_primitive() {
 
 	status_test_typechecker("typecheck wrong assign primitive");
 	char* filename = "test/typechecker/test-src/assign_primitive.dg";
@@ -72,7 +32,7 @@ static void test_typecheck_wrong_assign_primitive() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_wrong_number_of_args() {
+void test_typecheck_wrong_number_of_args() {
 
 	status_test_typechecker("typecheck wrong number of args");
 	char* filename = "test/typechecker/test-src/wrong_number_of_args.dg";
@@ -86,7 +46,7 @@ static void test_typecheck_wrong_number_of_args() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_wrong_type_of_arg() {
+void test_typecheck_wrong_type_of_arg() {
 
 	status_test_typechecker("typecheck wrong type of arg");
 	char* filename = "test/typechecker/test-src/wrong_type_of_arg.dg";
@@ -100,7 +60,7 @@ static void test_typecheck_wrong_type_of_arg() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_wrong_return_type() {
+void test_typecheck_wrong_return_type() {
 
 	status_test_typechecker("typecheck wrong return type");
 	char* filename = "test/typechecker/test-src/wrong_return_type.dg";
@@ -114,7 +74,7 @@ static void test_typecheck_wrong_return_type() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_binop_type_mismatch() {
+void test_typecheck_binop_type_mismatch() {
 
 	status_test_typechecker("typecheck binop type mismatch");
 	char* filename = "test/typechecker/test-src/binop_type_mismatch.dg";
@@ -128,7 +88,7 @@ static void test_typecheck_binop_type_mismatch() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_subr_not_found() {
+void test_typecheck_subr_not_found() {
 
 	status_test_typechecker("typecheck subr not found");
 	char* filename = "test/typechecker/test-src/subr_not_found.dg";
@@ -142,7 +102,7 @@ static void test_typecheck_subr_not_found() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_impure_called_in_pure() {
+void test_typecheck_impure_called_in_pure() {
 
 	status_test_typechecker("typecheck impure called in pure");
 	char* filename = "test/typechecker/test-src/impure_called_in_pure.dg";
@@ -156,7 +116,7 @@ static void test_typecheck_impure_called_in_pure() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_condition_requires_bool() {
+void test_typecheck_condition_requires_bool() {
 
 	status_test_typechecker("typecheck condition requires bool");
 	char* filename = "test/typechecker/test-src/condition_requires_bool.dg";
@@ -170,7 +130,7 @@ static void test_typecheck_condition_requires_bool() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_range_requires_int() {
+void test_typecheck_range_requires_int() {
 
 	status_test_typechecker("typecheck range requires int");
 	char* filename = "test/typechecker/test-src/range_requires_int.dg";
@@ -184,7 +144,7 @@ static void test_typecheck_range_requires_int() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_wrong_op_unop() {
+void test_typecheck_wrong_op_unop() {
 
 	status_test_typechecker("typecheck wrong op unop");
 	char* filename = "test/typechecker/test-src/wrong_op_unop.dg";
@@ -198,7 +158,7 @@ static void test_typecheck_wrong_op_unop() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_index_not_integer_type() {
+void test_typecheck_index_not_integer_type() {
 
 	status_test_typechecker("typecheck index not integer type");
 	char* filename = "test/typechecker/test-src/index_not_integer_type.dg";
@@ -212,7 +172,7 @@ static void test_typecheck_index_not_integer_type() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_too_many_indices() {
+void test_typecheck_too_many_indices() {
 
 	status_test_typechecker("typecheck too many indices");
 	char* filename = "test/typechecker/test-src/too_many_indices.dg";
@@ -227,7 +187,7 @@ static void test_typecheck_too_many_indices() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_local_var_not_a_subroutine() {
+void test_typecheck_local_var_not_a_subroutine() {
 
 	status_test_typechecker("typecheck local var not a subroutine");
 	char* filename = "test/typechecker/test-src/local_var_not_a_subroutine.dg";
@@ -241,7 +201,7 @@ static void test_typecheck_local_var_not_a_subroutine() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_var_not_found() {
+void test_typecheck_var_not_found() {
 
 	status_test_typechecker("typecheck var not found");
 	char* filename = "test/typechecker/test-src/var_not_found.dg";
@@ -255,7 +215,7 @@ static void test_typecheck_var_not_found() {
 	free_tc_errors(errors);
 }
 
-static void test_typecheck_all_type_errors() {
+void test_typecheck_all_type_errors() {
 
 	status_test_typechecker("typecheck all type errors");
 	char* filename = "test/typechecker/test-src/all_errors.dg";

--- a/compiler/test/typechecker/test_typechecker.h
+++ b/compiler/test/typechecker/test_typechecker.h
@@ -1,6 +1,17 @@
-#ifndef SMALLDRAGON_TOPLEVEL_TEST_TYPECHECKER_H
-#define SMALLDRAGON_TOPLEVEL_TEST_TYPECHECKER_H
+#pragma once
 
-void test_suite_typechecker();
-
-#endif
+void test_typecheck_wrong_assign_primitive();
+void test_typecheck_wrong_number_of_args();
+void test_typecheck_wrong_type_of_arg();
+void test_typecheck_wrong_return_type();
+void test_typecheck_binop_type_mismatch();
+void test_typecheck_subr_not_found();
+void test_typecheck_impure_called_in_pure();
+void test_typecheck_condition_requires_bool();
+void test_typecheck_range_requires_int();
+void test_typecheck_wrong_op_unop();
+void test_typecheck_index_not_integer_type();
+void test_typecheck_too_many_indices();
+void test_typecheck_local_var_not_a_subroutine();
+void test_typecheck_var_not_found();
+void test_typecheck_all_type_errors();

--- a/compiler/test/typeinference/test_typeinference.c
+++ b/compiler/test/typeinference/test_typeinference.c
@@ -10,48 +10,11 @@
 #include "test_typeinference.h"
 #include "test_typeinference_util.h"
 
-//term/expr/const
-static void test_infer_type_term();
-static void test_infer_type_unopterm();
-static void test_infer_type_expr();
-static void test_infer_type_expr_multiple_terms();
-
-//call
-static void test_infer_type_return_type_subroutine();
-static void test_infer_type_call_with_struct_member_access();
-static void test_infer_type_call_with_array_access();
-
-//variables
-static void test_infer_type_simplevar_no_indices();
-static void test_infer_type_simplevar_with_indices();
-static void test_infer_type_var_with_member_access();
-
-//type parameters
-static void test_infer_type_type_param();
-
 static void status_test_typeinference(char* msg) {
 	printf(" - [TEST] %s\n", msg);
 }
 
-void test_suite_typeinference() {
-	test_infer_type_term();
-	test_infer_type_unopterm();
-	test_infer_type_expr();
-	test_infer_type_expr_multiple_terms();
-
-	//call
-	test_infer_type_return_type_subroutine();
-	test_infer_type_call_with_struct_member_access();
-	test_infer_type_call_with_array_access();
-
-	test_infer_type_simplevar_no_indices();
-	test_infer_type_simplevar_with_indices();
-	test_infer_type_var_with_member_access();
-
-	test_infer_type_type_param();
-}
-
-static void test_infer_type_term() {
+void test_infer_type_term() {
 
 	status_test_typeinference("infer_type_term");
 
@@ -68,7 +31,7 @@ static void test_infer_type_term() {
 	free_type(t);
 }
 
-static void test_infer_type_unopterm() {
+void test_infer_type_unopterm() {
 
 	status_test_typeinference("infer_type_unopterm");
 
@@ -89,7 +52,7 @@ static void test_infer_type_unopterm() {
 	free_type(t);
 }
 
-static void test_infer_type_expr() {
+void test_infer_type_expr() {
 
 	status_test_typeinference("infer_type_expr");
 
@@ -110,7 +73,7 @@ static void test_infer_type_expr() {
 	free_type(t);
 }
 
-static void test_infer_type_expr_multiple_terms() {
+void test_infer_type_expr_multiple_terms() {
 
 	status_test_typeinference("infer_type_expr_multiple_terms");
 
@@ -132,7 +95,7 @@ static void test_infer_type_expr_multiple_terms() {
 	free_type(t);
 }
 
-static void test_infer_type_return_type_subroutine() {
+void test_infer_type_return_type_subroutine() {
 
 	status_test_typeinference("infer_type_return_type_subroutine");
 
@@ -151,7 +114,7 @@ static void test_infer_type_return_type_subroutine() {
 	free_type(t);
 }
 
-static void test_infer_type_call_with_struct_member_access() {
+void test_infer_type_call_with_struct_member_access() {
 
 	status_test_typeinference("infer_type_call_with_struct_member_access");
 
@@ -170,7 +133,7 @@ static void test_infer_type_call_with_struct_member_access() {
 	free_type(t);
 }
 
-static void test_infer_type_call_with_array_access() {
+void test_infer_type_call_with_array_access() {
 	status_test_typeinference("infer_type_call_with_array_access");
 
 	struct Type* t = typeinfer_in_file("test/typeinference/test-src/infer_type_call_with_array_access.dg");
@@ -188,7 +151,7 @@ static void test_infer_type_call_with_array_access() {
 	free_type(t);
 }
 
-static void test_infer_type_simplevar_no_indices() {
+void test_infer_type_simplevar_no_indices() {
 
 	status_test_typeinference("infer_type_simplevar_no_indices");
 
@@ -207,7 +170,7 @@ static void test_infer_type_simplevar_no_indices() {
 	free_type(t);
 }
 
-static void test_infer_type_simplevar_with_indices() {
+void test_infer_type_simplevar_with_indices() {
 
 	status_test_typeinference("infer_type_simplevar_with_indices");
 
@@ -226,7 +189,7 @@ static void test_infer_type_simplevar_with_indices() {
 	free_type(t);
 }
 
-static void test_infer_type_var_with_member_access() {
+void test_infer_type_var_with_member_access() {
 
 	status_test_typeinference("infer_type_var_with_member_access");
 
@@ -245,7 +208,7 @@ static void test_infer_type_var_with_member_access() {
 	free_type(t);
 }
 
-static void test_infer_type_type_param() {
+void test_infer_type_type_param() {
 
 	status_test_typeinference("infer_type_type_param");
 

--- a/compiler/test/typeinference/test_typeinference.h
+++ b/compiler/test/typeinference/test_typeinference.h
@@ -1,8 +1,22 @@
-#ifndef TEST_TYPEINFERENCE
-#define TEST_TYPEINFERENCE
+#pragma once
 
 #include <stdbool.h>
 
-void test_suite_typeinference();
+//term/expr/const
+void test_infer_type_term();
+void test_infer_type_unopterm();
+void test_infer_type_expr();
+void test_infer_type_expr_multiple_terms();
 
-#endif
+//call
+void test_infer_type_return_type_subroutine();
+void test_infer_type_call_with_struct_member_access();
+void test_infer_type_call_with_array_access();
+
+//variables
+void test_infer_type_simplevar_no_indices();
+void test_infer_type_simplevar_with_indices();
+void test_infer_type_var_with_member_access();
+
+//type parameters
+void test_infer_type_type_param();

--- a/compiler/test/x86_code_gen/test_x86_code_gen.c
+++ b/compiler/test/x86_code_gen/test_x86_code_gen.c
@@ -15,32 +15,3 @@
 void status_test_x86_codegen(char* msg) {
 	printf(" - [TEST] x86 codegen %s\n", msg);
 }
-
-void test_suite_x86_code_gen() {
-
-	test_x86_compile_tac_nop();
-	test_x86_compile_tac_const_value();
-
-	test_x86_compile_tac_store_const_addr();
-	test_x86_compile_tac_load_const_addr();
-
-	test_x86_compile_tac_binary_op_immediate();
-	test_x86_compile_tac_unary_op();
-	test_x86_compile_tac_binary_op();
-
-	test_x86_compile_tac_goto();
-	test_x86_compile_tac_if_goto();
-	test_x86_compile_tac_if_cmp_goto();
-
-	test_x86_compile_tac_return();
-	test_x86_compile_tac_copy();
-	test_x86_compile_tac_param();
-	//test_x86_compile_tac_call();
-	//test_x86_compile_tac_setup_stackframe();
-
-	test_x86_compile_tac_load();
-	test_x86_compile_tac_store();
-
-	test_x86_compile_tac_load_local();
-	test_x86_compile_tac_store_local();
-}

--- a/compiler/test/x86_code_gen/test_x86_code_gen.h
+++ b/compiler/test/x86_code_gen/test_x86_code_gen.h
@@ -1,4 +1,5 @@
 #pragma once
 
-void test_suite_x86_code_gen();
+#include "compile_ir/test_compile_tac.h"
+
 void status_test_x86_codegen(char* msg);


### PR DESCRIPTION
./sd-tests --testcase-duration

to better see which tests may need attention and optimization

resolves #81