### PR TITLE
test: compiler: optimize test duration

### DIFF
--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac.h
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac.h
@@ -4,28 +4,125 @@
 #include "libvmcu_utils/libvmcu_utils.h"
 
 void test_compile_tac_nop();
-void test_compile_tac_const_value();
+
+// TAC_CONST_VALUE
+void test_compile_tac_const_value_test_8bit();
+void test_compile_tac_const_value_test_16bit();
 
 void test_compile_tac_store_const_addr();
 void test_compile_tac_load_const_addr();
 
-void test_compile_tac_binary_op_immediate();
-void test_compile_tac_unary_op();
-void test_compile_tac_binary_op();
+// TAC_BINARY_OP_IMMEDIATE
+void test_compile_tac_binary_op_immediate_case_add_8bit();
+void test_compile_tac_binary_op_immediate_case_add_16bit();
+void test_compile_tac_binary_op_immediate_case_sub_8bit();
+void test_compile_tac_binary_op_immediate_case_sub_16bit();
+void test_compile_tac_binary_op_immediate_case_and_8bit();
+void test_compile_tac_binary_op_immediate_case_and_16bit();
+void test_compile_tac_binary_op_immediate_case_or_8bit();
+void test_compile_tac_binary_op_immediate_case_or_16bit();
+void test_compile_tac_binary_op_immediate_case_xor_8bit();
+void test_compile_tac_binary_op_immediate_case_xor_16bit();
+void test_compile_tac_binary_op_immediate_case_shift_left_8bit();
+void test_compile_tac_binary_op_immediate_case_shift_left_16bit();
+void test_compile_tac_binary_op_immediate_case_shift_right_8bit();
+void test_compile_tac_binary_op_immediate_case_shift_right_16bit();
 
+// TAC_UNARY_OP
+void test_compile_tac_unary_op_case_minus_8bit();
+void test_compile_tac_unary_op_case_minus_16bit();
+void test_compile_tac_unary_op_case_not();
+void test_compile_tac_unary_op_case_bitwise_neg_8bit();
+void test_compile_tac_unary_op_case_bitwise_neg_16bit();
+
+// TAC_BINARY_OP
+void test_compile_tac_binary_op_add_8bit();
+void test_compile_tac_binary_op_add_16bit();
+void test_compile_tac_binary_op_sub_8bit();
+void test_compile_tac_binary_op_sub_16bit();
+void test_compile_tac_binary_op_and_8bit();
+void test_compile_tac_binary_op_and_16bit();
+void test_compile_tac_binary_op_or_8bit();
+void test_compile_tac_binary_op_or_16bit();
+void test_compile_tac_binary_op_xor_8bit();
+void test_compile_tac_binary_op_xor_16bit();
+void test_compile_tac_binary_op_xor_mixed1();
+void test_compile_tac_binary_op_xor_mixed2();
+void test_compile_tac_binary_op_neq_true_8bit();
+void test_compile_tac_binary_op_neq_true_16bit();
+void test_compile_tac_binary_op_neq_false_8bit();
+void test_compile_tac_binary_op_neq_false_16bit();
+void test_compile_tac_binary_op_lt_true_8bit();
+void test_compile_tac_binary_op_lt_true_16bit();
+void test_compile_tac_binary_op_lt_false_8bit();
+void test_compile_tac_binary_op_lt_false_16bit();
+void test_compile_tac_binary_op_eq_true_8bit();
+void test_compile_tac_binary_op_eq_true_16bit();
+void test_compile_tac_binary_op_eq_false_8bit();
+void test_compile_tac_binary_op_eq_false_16bit();
+void test_compile_tac_binary_op_geq_true_8bit();
+void test_compile_tac_binary_op_geq_true_16bit();
+void test_compile_tac_binary_op_geq_false_8bit();
+void test_compile_tac_binary_op_geq_false_16bit();
+
+// TAC_GOTO
 void test_compile_tac_goto();
-void test_compile_tac_if_goto();
-void test_compile_tac_if_cmp_goto();
+
+// TAC_IF_GOTO
+void test_compile_tac_if_goto_case_true_8bit();
+void test_compile_tac_if_goto_case_true_16bit();
+void test_compile_tac_if_goto_case_false_8bit();
+void test_compile_tac_if_goto_case_false_16bit();
+void test_compile_tac_if_goto_case_mixed();
+
+// TAC_IF_CMP_GOTO
+void test_compile_tac_if_cmp_goto_case_eq_true_8bit();
+void test_compile_tac_if_cmp_goto_case_eq_true_16bit();
+void test_compile_tac_if_cmp_goto_case_eq_false_8bit();
+void test_compile_tac_if_cmp_goto_case_eq_false_16bit();
+void test_compile_tac_if_cmp_goto_case_neq_true_8bit();
+void test_compile_tac_if_cmp_goto_case_neq_true_16bit();
+void test_compile_tac_if_cmp_goto_case_neq_false_8bit();
+void test_compile_tac_if_cmp_goto_case_neq_false_16bit();
+void test_compile_tac_if_cmp_goto_case_lt_true_8bit();
+void test_compile_tac_if_cmp_goto_case_lt_true_16bit();
+void test_compile_tac_if_cmp_goto_case_lt_false_8bit();
+void test_compile_tac_if_cmp_goto_case_lt_false_16bit();
+void test_compile_tac_if_cmp_goto_case_ge_true_8bit();
+void test_compile_tac_if_cmp_goto_case_ge_true_16bit();
+void test_compile_tac_if_cmp_goto_case_ge_false_8bit();
+void test_compile_tac_if_cmp_goto_case_ge_false_16bit();
+
+// TAC_RETURN
 void test_compile_tac_return();
 
-void test_compile_tac_copy();
-void test_compile_tac_param();
-void test_compile_tac_call();
+// TAC_COPY
+void test_compile_tac_copy_case_8bit();
+void test_compile_tac_copy_case_16bit();
 
-void test_compile_tac_load();
-void test_compile_tac_store();
+// TAC_PARAM
+void test_compile_tac_param_case_8bit();
+void test_compile_tac_param_case_16bit();
 
+// TAC_CALL
+void test_compile_tac_call_case_recurses();
+void test_compile_tac_call_case_returns_value();
+void test_compile_tac_call_case_1_param();
+
+// TAC_LOAD
+void test_compile_tac_load_case_8bit_addr();
+void test_compile_tac_load_case_16bit_addr();
+
+// TAC_STORE
+void test_compile_tac_store_case_8bit_value_8bit_addr();
+void test_compile_tac_store_case_16bit_value_8bit_addr();
+void test_compile_tac_store_case_8bit_value_16bit_addr();
+void test_compile_tac_store_case_16bit_value_16bit_addr();
+
+// TAC_SETUP_SP
 void test_compile_tac_setup_sp();
+
+// TAC_SETUP_STACKFRAME
 void test_compile_tac_setup_stackframe();
 
 #endif

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_binary_op.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_binary_op.c
@@ -15,97 +15,17 @@
 
 #include "test_compile_tac.h"
 
-static void test_compile_tac_binary_op_add_8bit();
-static void test_compile_tac_binary_op_add_16bit();
-static void test_compile_tac_binary_op_sub_8bit();
-static void test_compile_tac_binary_op_sub_16bit();
-static void test_compile_tac_binary_op_and_8bit();
-static void test_compile_tac_binary_op_and_16bit();
-static void test_compile_tac_binary_op_or_8bit();
-static void test_compile_tac_binary_op_or_16bit();
-
-static void test_compile_tac_binary_op_xor_8bit();
-static void test_compile_tac_binary_op_xor_16bit();
-static void test_compile_tac_binary_op_xor_mixed1();
-static void test_compile_tac_binary_op_xor_mixed2();
-
-static void test_compile_tac_binary_op_neq_true_8bit();
-static void test_compile_tac_binary_op_neq_true_16bit();
-
-static void test_compile_tac_binary_op_neq_false_8bit();
-static void test_compile_tac_binary_op_neq_false_16bit();
-
-static void test_compile_tac_binary_op_lt_true_8bit();
-static void test_compile_tac_binary_op_lt_true_16bit();
-
-static void test_compile_tac_binary_op_lt_false_8bit();
-static void test_compile_tac_binary_op_lt_false_16bit();
-
-static void test_compile_tac_binary_op_eq_true_8bit();
-static void test_compile_tac_binary_op_eq_true_16bit();
-
-static void test_compile_tac_binary_op_eq_false_8bit();
-static void test_compile_tac_binary_op_eq_false_16bit();
-
-static void test_compile_tac_binary_op_geq_true_8bit();
-static void test_compile_tac_binary_op_geq_true_16bit();
-static void test_compile_tac_binary_op_geq_false_8bit();
-static void test_compile_tac_binary_op_geq_false_16bit();
-
 static int16_t make16(uint8_t high, uint8_t low) {
 	return (high << 8) | low;
 }
 
-void test_compile_tac_binary_op() {
-
-	test_compile_tac_binary_op_add_8bit();
-	test_compile_tac_binary_op_add_16bit();
-
-	test_compile_tac_binary_op_sub_8bit();
-	test_compile_tac_binary_op_sub_16bit();
-
-	test_compile_tac_binary_op_and_8bit();
-	test_compile_tac_binary_op_and_16bit();
-
-	test_compile_tac_binary_op_or_8bit();
-	test_compile_tac_binary_op_or_16bit();
-
-	test_compile_tac_binary_op_xor_8bit();
-	test_compile_tac_binary_op_xor_16bit();
-	test_compile_tac_binary_op_xor_mixed1();
-	test_compile_tac_binary_op_xor_mixed2();
-
-	test_compile_tac_binary_op_neq_true_8bit();
-	test_compile_tac_binary_op_neq_true_16bit();
-
-	test_compile_tac_binary_op_neq_false_8bit();
-	test_compile_tac_binary_op_neq_false_16bit();
-
-	test_compile_tac_binary_op_lt_true_8bit();
-	test_compile_tac_binary_op_lt_true_16bit();
-
-	test_compile_tac_binary_op_lt_false_8bit();
-	test_compile_tac_binary_op_lt_false_16bit();
-
-	test_compile_tac_binary_op_eq_true_8bit();
-	test_compile_tac_binary_op_eq_true_16bit();
-
-	test_compile_tac_binary_op_eq_false_8bit();
-	test_compile_tac_binary_op_eq_false_16bit();
-
-	test_compile_tac_binary_op_geq_true_8bit();
-	test_compile_tac_binary_op_geq_true_16bit();
-	test_compile_tac_binary_op_geq_false_8bit();
-	test_compile_tac_binary_op_geq_false_16bit();
-}
-
-static void test_compile_tac_binary_op_add_8bit() {
+void test_compile_tac_binary_op_add_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP + (8 bit)");
 
 	const int8_t start = 0x01;
 
-	for (int8_t change = 0; change < 100; change += 10) {
+	for (int8_t change = 0; change < 4; change++) {
 
 		const int8_t expected = start + change;
 
@@ -129,13 +49,13 @@ static void test_compile_tac_binary_op_add_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_add_16bit() {
+void test_compile_tac_binary_op_add_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP + (16 bit)");
 
 	const int16_t start = 0xabcd;
 
-	for (int16_t change = 0; change < 1000; change += 100) {
+	for (int16_t change = 0; change < 500; change += 100) {
 
 		const int16_t expected = start + change;
 
@@ -162,12 +82,12 @@ static void test_compile_tac_binary_op_add_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_sub_8bit() {
+void test_compile_tac_binary_op_sub_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP - (8 bit)");
 
 	int8_t start = 0;
-	for (int8_t change = -10; change < 100; change += 10) {
+	for (int8_t change = -10; change < 40; change += 10) {
 
 		int8_t expected = start - change;
 
@@ -191,12 +111,12 @@ static void test_compile_tac_binary_op_sub_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_sub_16bit() {
+void test_compile_tac_binary_op_sub_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP - (16 bit)");
 
 	int16_t start = 0xabcd;
-	for (int16_t change = -0x500; change < 0x500; change += 0x100) {
+	for (int16_t change = -0x200; change < 0x300; change += 0x100) {
 
 		int16_t expected = start - change;
 
@@ -221,12 +141,12 @@ static void test_compile_tac_binary_op_sub_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_and_8bit() {
+void test_compile_tac_binary_op_and_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP & (8 bit)");
 
 	uint8_t start = 0x45;
-	for (uint8_t change = 0xf0; change < 0xfe; change++) {
+	for (uint8_t change = 0xf0; change < 0xf3; change++) {
 
 		int8_t expected = start & change;
 
@@ -250,12 +170,12 @@ static void test_compile_tac_binary_op_and_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_and_16bit() {
+void test_compile_tac_binary_op_and_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP & (16 bit)");
 
 	int16_t start = 0xabcd;
-	for (int16_t change = 0x1000; change < 0x1010; change++) {
+	for (int16_t change = 0x1000; change < 0x1003; change++) {
 
 		int16_t expected = start & change;
 
@@ -280,12 +200,12 @@ static void test_compile_tac_binary_op_and_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_or_8bit() {
+void test_compile_tac_binary_op_or_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP | (8 bit)");
 
 	int8_t start = 0xab;
-	for (int8_t change = 0x30; change < 0x40; change++) {
+	for (int8_t change = 0x30; change < 0x33; change++) {
 
 		int8_t expected = start | change;
 
@@ -309,12 +229,12 @@ static void test_compile_tac_binary_op_or_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_or_16bit() {
+void test_compile_tac_binary_op_or_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP | (16 bit)");
 
 	int16_t start = 0xabcd;
-	for (int16_t change = 0x1400; change < 0x1410; change++) {
+	for (int16_t change = 0x1400; change < 0x1403; change++) {
 		int16_t expected = start | change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -338,12 +258,12 @@ static void test_compile_tac_binary_op_or_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_xor_8bit() {
+void test_compile_tac_binary_op_xor_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP ^ (8 bit)");
 
 	uint8_t start = 0xab;
-	for (uint8_t change = 0xf0; change < 0xff; change++) {
+	for (uint8_t change = 0xf0; change < 0xf3; change++) {
 		int8_t expected = start ^ change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -366,12 +286,12 @@ static void test_compile_tac_binary_op_xor_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_xor_16bit() {
+void test_compile_tac_binary_op_xor_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP ^ (16 bit)");
 
 	uint16_t start = 0x1bcd;
-	for (uint16_t change = 0x4000; change < 0x4010; change++) {
+	for (uint16_t change = 0x4000; change < 0x4003; change++) {
 
 		uint16_t expected = start ^ change;
 
@@ -400,7 +320,7 @@ static void test_compile_tac_binary_op_xor_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_xor_mixed1() {
+void test_compile_tac_binary_op_xor_mixed1() {
 
 	status_test_codegen("TAC_BINARY_OP ^ (mixed1, 8bit, 16bit) [FAILING - disabled]");
 	return;
@@ -430,13 +350,13 @@ static void test_compile_tac_binary_op_xor_mixed1() {
 	vmcu_system_dtor(system);
 }
 
-static void test_compile_tac_binary_op_xor_mixed2() {
+void test_compile_tac_binary_op_xor_mixed2() {
 
 	status_test_codegen("TAC_BINARY_OP ^ (mixed2, 16bit, 8bit)");
 
 	const uint16_t start = 0xabcd;
 
-	for (uint16_t change = 0x1000; change < 0x1010; change++) {
+	for (uint16_t change = 0x1000; change < 0x1003; change++) {
 
 		const uint16_t expected = start ^ change;
 
@@ -463,11 +383,11 @@ static void test_compile_tac_binary_op_xor_mixed2() {
 	}
 }
 
-static void test_compile_tac_binary_op_neq_true_8bit() {
+void test_compile_tac_binary_op_neq_true_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP != true (8 bit)");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 
 		int8_t value2 = value1 + 1;
 
@@ -491,11 +411,11 @@ static void test_compile_tac_binary_op_neq_true_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_neq_true_16bit() {
+void test_compile_tac_binary_op_neq_true_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP != true (16 bit)");
 
-	for (int16_t value1 = 0x100; value1 < 0x10f; value1++) {
+	for (int16_t value1 = 0x100; value1 < 0x103; value1++) {
 
 		int16_t value2 = 0x200;
 
@@ -519,11 +439,11 @@ static void test_compile_tac_binary_op_neq_true_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_neq_false_8bit() {
+void test_compile_tac_binary_op_neq_false_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP != false (8 bit)");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 
 		int8_t value2 = value1;
 
@@ -547,11 +467,11 @@ static void test_compile_tac_binary_op_neq_false_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_neq_false_16bit() {
+void test_compile_tac_binary_op_neq_false_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP != false (16 bit)");
 
-	for (int16_t value1 = 0x1000; value1 < 0x100f; value1++) {
+	for (int16_t value1 = 0x1000; value1 < 0x1003; value1++) {
 
 		int16_t value2 = value1;
 
@@ -575,11 +495,11 @@ static void test_compile_tac_binary_op_neq_false_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_lt_true_8bit() {
+void test_compile_tac_binary_op_lt_true_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP < true (8 bit)");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 
 		int8_t value2 = value1 + 1;
 
@@ -603,11 +523,11 @@ static void test_compile_tac_binary_op_lt_true_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_lt_true_16bit() {
+void test_compile_tac_binary_op_lt_true_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP < true (16 bit)");
 
-	for (uint16_t value1 = 0x100; value1 < 0x110; value1++) {
+	for (uint16_t value1 = 0x100; value1 < 0x103; value1++) {
 
 		uint16_t value2 = 0x200;
 
@@ -631,11 +551,11 @@ static void test_compile_tac_binary_op_lt_true_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_lt_false_8bit() {
+void test_compile_tac_binary_op_lt_false_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP < false (8 bit)");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 		int8_t value2 = value1;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -658,12 +578,12 @@ static void test_compile_tac_binary_op_lt_false_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_lt_false_16bit() {
+void test_compile_tac_binary_op_lt_false_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP < false (16 bit)");
 
-	for (uint16_t value1 = 0x100; value1 < 0x104; value1++) {
-		for (uint16_t value2 = value1 - 4; value2 <= value1; value2++) {
+	for (uint16_t value1 = 0x100; value1 < 0x102; value1++) {
+		for (uint16_t value2 = value1 - 3; value2 <= value1; value2++) {
 
 			struct TACBuffer* b = tacbuffer_ctor();
 
@@ -686,11 +606,11 @@ static void test_compile_tac_binary_op_lt_false_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_eq_true_8bit() {
+void test_compile_tac_binary_op_eq_true_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP == true (8 bit)");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 		int8_t value2 = value1;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -713,11 +633,11 @@ static void test_compile_tac_binary_op_eq_true_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_eq_true_16bit() {
+void test_compile_tac_binary_op_eq_true_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP == true (16 bit)");
 
-	for (uint16_t value1 = 0xff00; value1 < 0xff0f; value1++) {
+	for (uint16_t value1 = 0xff00; value1 < 0xff03; value1++) {
 
 		uint16_t value2 = value1;
 
@@ -741,11 +661,11 @@ static void test_compile_tac_binary_op_eq_true_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_eq_false_8bit() {
+void test_compile_tac_binary_op_eq_false_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP == false (8 bit)");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 		int8_t value2 = value1 + 1;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -768,11 +688,11 @@ static void test_compile_tac_binary_op_eq_false_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_eq_false_16bit() {
+void test_compile_tac_binary_op_eq_false_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP == false (16 bit)");
 
-	for (int16_t value1 = 0x0100; value1 < 0x010f; value1++) {
+	for (int16_t value1 = 0x0100; value1 < 0x0103; value1++) {
 
 		int16_t value2 = 0x0200;
 
@@ -796,11 +716,11 @@ static void test_compile_tac_binary_op_eq_false_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_geq_true_8bit() {
+void test_compile_tac_binary_op_geq_true_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP >= true (8 bit)");
 
-	for (uint8_t value1 = 0x03; value1 < 0x0f; value1++) {
+	for (uint8_t value1 = 0x03; value1 < 0x06; value1++) {
 
 		uint8_t value2 = 0x03;
 
@@ -824,11 +744,11 @@ static void test_compile_tac_binary_op_geq_true_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_geq_true_16bit() {
+void test_compile_tac_binary_op_geq_true_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP >= true (16 bit)");
 
-	for (uint16_t value1 = 0x0103; value1 < 0x010f; value1++) {
+	for (uint16_t value1 = 0x0103; value1 < 0x0106; value1++) {
 		uint16_t value2 = 0x0103;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -851,11 +771,11 @@ static void test_compile_tac_binary_op_geq_true_16bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_geq_false_8bit() {
+void test_compile_tac_binary_op_geq_false_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP >= false (8 bit)");
 
-	for (uint8_t value1 = 0x03; value1 < 0x0f; value1++) {
+	for (uint8_t value1 = 0x03; value1 < 0x06; value1++) {
 
 		uint8_t value2 = 0x10;
 
@@ -879,11 +799,11 @@ static void test_compile_tac_binary_op_geq_false_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_geq_false_16bit() {
+void test_compile_tac_binary_op_geq_false_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP >= false (16 bit)");
 
-	for (uint16_t value1 = 0x0103; value1 < 0x010f; value1++) {
+	for (uint16_t value1 = 0x0103; value1 < 0x0106; value1++) {
 		uint16_t value2 = 0x0203;
 
 		struct TACBuffer* b = tacbuffer_ctor();

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_binary_op_immediate.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_binary_op_immediate.c
@@ -15,52 +15,13 @@
 
 #include "test_compile_tac.h"
 
-static void case_add_8bit();
-static void case_add_16bit();
-static void case_sub_8bit();
-static void case_sub_16bit();
-static void case_and_8bit();
-static void case_and_16bit();
-static void case_or_8bit();
-static void case_or_16bit();
-static void case_xor_8bit();
-static void case_xor_16bit();
-static void case_shift_left_8bit();
-static void case_shift_left_16bit();
-static void case_shift_right_8bit();
-static void case_shift_right_16bit();
-
-void test_compile_tac_binary_op_immediate() {
-
-	case_add_8bit();
-	case_add_16bit();
-
-	case_sub_8bit();
-	case_sub_16bit();
-
-	case_and_8bit();
-	case_and_16bit();
-
-	case_or_8bit();
-	case_or_16bit();
-
-	case_xor_8bit();
-	case_xor_16bit();
-
-	case_shift_left_8bit();
-	case_shift_left_16bit();
-
-	case_shift_right_8bit();
-	case_shift_right_16bit();
-}
-
-static void case_add_8bit() {
+void test_compile_tac_binary_op_immediate_case_add_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE + (8 bit)");
 
 	int8_t start = 0x83;
 
-	for (uint8_t change = 0; change < 20; change++) {
+	for (uint8_t change = 0; change < 5; change++) {
 
 		int8_t expected = start + change;
 
@@ -83,7 +44,7 @@ static void case_add_8bit() {
 	}
 }
 
-static void case_add_16bit() {
+void test_compile_tac_binary_op_immediate_case_add_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE + (16 bit)");
 
@@ -91,7 +52,7 @@ static void case_add_16bit() {
 
 	//printf("start = %d (0x%x)\n", start, start);
 
-	for (uint16_t change = 0; change < 20; change++) {
+	for (uint16_t change = 0; change < 5; change++) {
 
 		//printf("change = %d (0x%x)\n", change, change);
 
@@ -123,13 +84,13 @@ static void case_add_16bit() {
 	}
 }
 
-static void case_sub_8bit() {
+void test_compile_tac_binary_op_immediate_case_sub_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE - (8 bit)");
 
 	int8_t start = 44;
 
-	for (uint8_t change = 0; change < 20; change++) {
+	for (uint8_t change = 0; change < 5; change++) {
 
 		const int8_t expected = start - change;
 
@@ -152,13 +113,13 @@ static void case_sub_8bit() {
 	}
 }
 
-static void case_sub_16bit() {
+void test_compile_tac_binary_op_immediate_case_sub_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE - (16 bit)");
 
 	int16_t start = 3483;
 
-	for (uint8_t change = 0; change < 20; change++) {
+	for (uint8_t change = 0; change < 5; change++) {
 
 		const int16_t expected = start - change;
 
@@ -186,12 +147,12 @@ static void case_sub_16bit() {
 	}
 }
 
-static void case_and_8bit() {
+void test_compile_tac_binary_op_immediate_case_and_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE & (8 bit)");
 
 	int8_t start = 0xe3;
-	for (int8_t change = 0; change < 10; change++) {
+	for (int8_t change = 0; change < 5; change++) {
 		int8_t expected = start & change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -212,12 +173,12 @@ static void case_and_8bit() {
 	}
 }
 
-static void case_and_16bit() {
+void test_compile_tac_binary_op_immediate_case_and_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE & (16 bit)");
 
 	uint16_t start = 0xabcd;
-	for (uint16_t change = 0x1001; change < 0x1010; change++) {
+	for (uint16_t change = 0x1001; change < 0x1006; change++) {
 		uint16_t expected = start & change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -241,12 +202,12 @@ static void case_and_16bit() {
 	}
 }
 
-static void case_or_8bit() {
+void test_compile_tac_binary_op_immediate_case_or_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE | (8 bit)");
 
 	int8_t start = 0xc7;
-	for (int8_t change = 0; change < 10; change++) {
+	for (int8_t change = 0; change < 5; change++) {
 		int8_t expected = start | change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -267,12 +228,12 @@ static void case_or_8bit() {
 	}
 }
 
-static void case_or_16bit() {
+void test_compile_tac_binary_op_immediate_case_or_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE | (16 bit)");
 
 	uint16_t start = 0xabcd;
-	for (uint16_t change = 0x1000; change < 0x1010; change++) {
+	for (uint16_t change = 0x1000; change < 0x1005; change++) {
 		uint16_t expected = start | change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -296,12 +257,12 @@ static void case_or_16bit() {
 	}
 }
 
-static void case_xor_8bit() {
+void test_compile_tac_binary_op_immediate_case_xor_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE ^ (8 bit)");
 
 	int8_t start = 0xc3;
-	for (int8_t change = 0; change < 10; change++) {
+	for (int8_t change = 0; change < 5; change++) {
 		int8_t expected = start ^ change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -322,12 +283,12 @@ static void case_xor_8bit() {
 	}
 }
 
-static void case_xor_16bit() {
+void test_compile_tac_binary_op_immediate_case_xor_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE ^ (16 bit)");
 
 	uint16_t start = 0xabcd;
-	for (uint16_t change = 0x1000; change < 0x1010; change++) {
+	for (uint16_t change = 0x1000; change < 0x1005; change++) {
 		uint16_t expected = start ^ change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -351,7 +312,7 @@ static void case_xor_16bit() {
 	}
 }
 
-static void case_shift_left_8bit() {
+void test_compile_tac_binary_op_immediate_case_shift_left_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE << (8 bit)");
 
@@ -379,7 +340,7 @@ static void case_shift_left_8bit() {
 	}
 }
 
-static void case_shift_left_16bit() {
+void test_compile_tac_binary_op_immediate_case_shift_left_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE << (16 bit)");
 
@@ -414,7 +375,7 @@ static void case_shift_left_16bit() {
 	}
 }
 
-static void case_shift_right_8bit() {
+void test_compile_tac_binary_op_immediate_case_shift_right_8bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE >> (8 bit)");
 
@@ -442,7 +403,7 @@ static void case_shift_right_8bit() {
 	}
 }
 
-static void case_shift_right_16bit() {
+void test_compile_tac_binary_op_immediate_case_shift_right_16bit() {
 
 	status_test_codegen("TAC_BINARY_OP_IMMEDIATE >> (16 bit)");
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_call.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_call.c
@@ -15,18 +15,7 @@
 
 #include "test_compile_tac.h"
 
-static void case_recurse();
-static void case_returns_value();
-static void case_1_param();
-
-void test_compile_tac_call() {
-
-	case_recurse();
-	case_returns_value();
-	case_1_param();
-}
-
-static void case_recurse() {
+void test_compile_tac_call_case_recurses() {
 
 	status_test_codegen("TAC_CALL - recurse");
 
@@ -55,7 +44,7 @@ static void case_recurse() {
 	vmcu_system_dtor(system);
 }
 
-static void case_returns_value() {
+void test_compile_tac_call_case_returns_value() {
 
 	status_test_codegen("TAC_CALL - returns value");
 
@@ -78,7 +67,7 @@ static void case_returns_value() {
 	vmcu_system_dtor(system);
 }
 
-static void case_1_param() {
+void test_compile_tac_call_case_1_param() {
 
 	status_test_codegen("TAC_CALL - 1 param [TODO]");
 }

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_const_value.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_const_value.c
@@ -15,20 +15,11 @@
 
 #include "test_compile_tac.h"
 
-static void test_8bit();
-static void test_16bit();
-
-void test_compile_tac_const_value() {
-
-	test_8bit();
-	test_16bit();
-}
-
-static void test_8bit() {
+void test_compile_tac_const_value_test_8bit() {
 
 	status_test_codegen("TAC_CONST_VALUE - 8 bit");
 
-	for (int8_t fixed_value = -100; fixed_value < 100; fixed_value += 10) {
+	for (int8_t fixed_value = -40; fixed_value < 40; fixed_value += 10) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -52,11 +43,11 @@ static void test_8bit() {
 	}
 }
 
-static void test_16bit() {
+void test_compile_tac_const_value_test_16bit() {
 
 	status_test_codegen("TAC_CONST_VALUE - 16 bit");
 
-	for (int16_t fixed_value = -30000; fixed_value < 30000; fixed_value += 2000) {
+	for (int16_t fixed_value = -10000; fixed_value < 10000; fixed_value += 2000) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_copy.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_copy.c
@@ -15,20 +15,11 @@
 
 #include "test_compile_tac.h"
 
-static void test_8bit();
-static void test_16bit();
-
-void test_compile_tac_copy() {
-
-	test_8bit();
-	test_16bit();
-}
-
-static void test_8bit() {
+void test_compile_tac_copy_case_8bit() {
 
 	status_test_codegen("TAC_COPY - 8 bit");
 
-	for (int8_t fixed_value = 0; fixed_value < 20; fixed_value++) {
+	for (int8_t fixed_value = 0; fixed_value < 5; fixed_value++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -46,11 +37,11 @@ static void test_8bit() {
 	}
 }
 
-static void test_16bit() {
+void test_compile_tac_copy_case_16bit() {
 
 	status_test_codegen("TAC_COPY - 16 bit");
 
-	for (uint16_t fixed_value = 0x100; fixed_value < 0x110; fixed_value++) {
+	for (uint16_t fixed_value = 0x100; fixed_value < 0x105; fixed_value++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_if_cmp_goto.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_if_cmp_goto.c
@@ -15,47 +15,7 @@
 
 #include "test_compile_tac.h"
 
-static void case_eq_true_8bit();
-static void case_eq_true_16bit();
-static void case_eq_false_8bit();
-static void case_eq_false_16bit();
-static void case_neq_true_8bit();
-static void case_neq_true_16bit();
-static void case_neq_false_8bit();
-static void case_neq_false_16bit();
-static void case_lt_true_8bit();
-static void case_lt_true_16bit();
-static void case_lt_false_8bit();
-static void case_lt_false_16bit();
-static void case_ge_true_8bit();
-static void case_ge_true_16bit();
-static void case_ge_false_8bit();
-static void case_ge_false_16bit();
-
 static void common(int a, enum TAC_OP op, int b, bool expect_true);
-
-void test_compile_tac_if_cmp_goto() {
-
-	case_eq_true_8bit();
-	case_eq_true_16bit();
-	case_eq_false_8bit();
-	case_eq_false_16bit();
-
-	case_neq_true_8bit();
-	case_neq_true_16bit();
-	case_neq_false_8bit();
-	case_neq_false_16bit();
-
-	case_lt_true_8bit();
-	case_lt_true_16bit();
-	case_lt_false_8bit();
-	case_lt_false_16bit();
-
-	case_ge_true_8bit();
-	case_ge_true_16bit();
-	case_ge_false_8bit();
-	case_ge_false_16bit();
-}
 
 static void common(int a1, enum TAC_OP op, int a2, bool expect_true) {
 
@@ -108,112 +68,112 @@ static void common(int a1, enum TAC_OP op, int a2, bool expect_true) {
 	vmcu_system_dtor(system);
 }
 
-static void case_eq_true_8bit() {
+void test_compile_tac_if_cmp_goto_case_eq_true_8bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO == true (8 bit)");
 
 	common(1, TAC_OP_CMP_EQ, 1, true);
 }
 
-static void case_eq_true_16bit() {
+void test_compile_tac_if_cmp_goto_case_eq_true_16bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO == true (16 bit)");
 
 	common(0xffff, TAC_OP_CMP_EQ, 0xffff, true);
 }
 
-static void case_eq_false_8bit() {
+void test_compile_tac_if_cmp_goto_case_eq_false_8bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO == false (8 bit)");
 
 	common(1, TAC_OP_CMP_EQ, 2, false);
 }
 
-static void case_eq_false_16bit() {
+void test_compile_tac_if_cmp_goto_case_eq_false_16bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO == false (16 bit)");
 
 	common(0x0100, TAC_OP_CMP_EQ, 0x0200, false);
 }
 
-static void case_neq_true_8bit() {
+void test_compile_tac_if_cmp_goto_case_neq_true_8bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO != true (8 bit)");
 
 	common(1, TAC_OP_CMP_NEQ, 2, true);
 }
 
-static void case_neq_true_16bit() {
+void test_compile_tac_if_cmp_goto_case_neq_true_16bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO != true (16 bit)");
 
 	common(0x0100, TAC_OP_CMP_NEQ, 0x0200, true);
 }
 
-static void case_neq_false_8bit() {
+void test_compile_tac_if_cmp_goto_case_neq_false_8bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO != false (8 bit)");
 
 	common(1, TAC_OP_CMP_NEQ, 1, false);
 }
 
-static void case_neq_false_16bit() {
+void test_compile_tac_if_cmp_goto_case_neq_false_16bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO != false (16 bit)");
 
 	common(0x1234, TAC_OP_CMP_NEQ, 0x1234, false);
 }
 
-static void case_lt_true_8bit() {
+void test_compile_tac_if_cmp_goto_case_lt_true_8bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO < true (8 bit)");
 
 	common(1, TAC_OP_CMP_LT, 4, true);
 }
 
-static void case_lt_true_16bit() {
+void test_compile_tac_if_cmp_goto_case_lt_true_16bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO < true (16 bit)");
 
 	common(0x0100, TAC_OP_CMP_LT, 0x0200, true);
 }
 
-static void case_lt_false_8bit() {
+void test_compile_tac_if_cmp_goto_case_lt_false_8bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO < false (8 bit)");
 
 	common(5, TAC_OP_CMP_LT, 4, false);
 }
 
-static void case_lt_false_16bit() {
+void test_compile_tac_if_cmp_goto_case_lt_false_16bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO < false (16 bit)");
 
 	common(0x0100, TAC_OP_CMP_LT, 0x0001, false);
 }
 
-static void case_ge_true_8bit() {
+void test_compile_tac_if_cmp_goto_case_ge_true_8bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO >= true (8 bit)");
 
 	common(4, TAC_OP_CMP_GE, 4, true);
 }
 
-static void case_ge_true_16bit() {
+void test_compile_tac_if_cmp_goto_case_ge_true_16bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO >= true (16 bit)");
 
 	common(0x0200, TAC_OP_CMP_GE, 0x0101, true);
 }
 
-static void case_ge_false_8bit() {
+void test_compile_tac_if_cmp_goto_case_ge_false_8bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO >= false (8 bit)");
 
 	common(2, TAC_OP_CMP_GE, 4, false);
 }
 
-static void case_ge_false_16bit() {
+void test_compile_tac_if_cmp_goto_case_ge_false_16bit() {
 
 	status_test_codegen("TAC_IF_CMP_GOTO >= false (16 bit)");
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_if_goto.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_if_goto.c
@@ -15,24 +15,7 @@
 
 #include "test_compile_tac.h"
 
-static void case_true_8bit();
-static void case_true_16bit();
-static void case_false_8bit();
-static void case_false_16bit();
-static void case_mixed();
-
-void test_compile_tac_if_goto() {
-
-	case_true_8bit();
-	case_true_16bit();
-
-	case_false_8bit();
-	case_false_16bit();
-
-	case_mixed();
-}
-
-static void case_true_8bit() {
+void test_compile_tac_if_goto_case_true_8bit() {
 
 	status_test_codegen("TAC_IF_GOTO true (8 bit)");
 
@@ -66,7 +49,7 @@ static void case_true_8bit() {
 	vmcu_system_dtor(system);
 }
 
-static void case_true_16bit() {
+void test_compile_tac_if_goto_case_true_16bit() {
 
 	status_test_codegen("TAC_IF_GOTO true (16 bit)");
 
@@ -100,7 +83,7 @@ static void case_true_16bit() {
 	vmcu_system_dtor(system);
 }
 
-static void case_false_8bit() {
+void test_compile_tac_if_goto_case_false_8bit() {
 
 	status_test_codegen("TAC_IF_GOTO false (8 bit)");
 
@@ -133,7 +116,7 @@ static void case_false_8bit() {
 	vmcu_system_dtor(system);
 }
 
-static void case_false_16bit() {
+void test_compile_tac_if_goto_case_false_16bit() {
 
 	status_test_codegen("TAC_IF_GOTO false (16 bit)");
 
@@ -166,7 +149,7 @@ static void case_false_16bit() {
 	vmcu_system_dtor(system);
 }
 
-static void case_mixed() {
+void test_compile_tac_if_goto_case_mixed() {
 
 	status_test_codegen("TAC_IF_GOTO mixed");
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_load.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_load.c
@@ -15,21 +15,12 @@
 
 #include "test_compile_tac.h"
 
-static void test_8bit_addr();
-static void test_16bit_addr();
-
-void test_compile_tac_load() {
-
-	test_8bit_addr();
-	test_16bit_addr();
-}
-
-void test_8bit_addr() {
+void test_compile_tac_load_case_8bit_addr() {
 
 	status_test_codegen("TAC_LOAD (8 bit address)");
 
 	const uint16_t addr = 0xc7;
-	for (int8_t fixed_value = 0x33; fixed_value < 0x43; fixed_value++) {
+	for (int8_t fixed_value = 0x33; fixed_value < 0x36; fixed_value++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -52,12 +43,12 @@ void test_8bit_addr() {
 	}
 }
 
-void test_16bit_addr() {
+void test_compile_tac_load_case_16bit_addr() {
 
 	status_test_codegen("TAC_LOAD (16 bit address)");
 
 	const uint16_t addr = 0x0103;
-	for (int8_t fixed_value = 0x20; fixed_value < 0x2f; fixed_value++) {
+	for (int8_t fixed_value = 0x20; fixed_value < 0x24; fixed_value++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_load_const_addr.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_load_const_addr.c
@@ -21,7 +21,7 @@ void test_compile_tac_load_const_addr() {
 
 	const uint16_t addr = 0x100 + 17;
 
-	for (int8_t fixed_value = 0x55; fixed_value < 0x65; fixed_value++) {
+	for (int8_t fixed_value = 0x55; fixed_value < 0x65; fixed_value += 2) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_param.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_param.c
@@ -15,16 +15,7 @@
 
 #include "test_compile_tac.h"
 
-static void test_param_8bit();
-static void test_param_16bit();
-
-void test_compile_tac_param() {
-
-	test_param_8bit();
-	test_param_16bit();
-}
-
-static void test_param_8bit() {
+void test_compile_tac_param_case_8bit() {
 
 	status_test_codegen("TAC_PARAM - (8 bit)");
 
@@ -62,7 +53,7 @@ static void test_param_8bit() {
 	vmcu_system_dtor(system);
 }
 
-static void test_param_16bit() {
+void test_compile_tac_param_case_16bit() {
 
 	status_test_codegen("TAC_PARAM - (16 bit)");
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_return.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_return.c
@@ -19,7 +19,7 @@ void test_compile_tac_return() {
 
 	status_test_codegen("TAC_RETURN");
 
-	for (int8_t value = 0x54; value < 0x65; value++) {
+	for (int8_t value = 0x54; value < 0x58; value++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_store.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_store.c
@@ -15,20 +15,7 @@
 
 #include "test_compile_tac.h"
 
-static void test_8bit_value_8bit_addr();
-static void test_16bit_value_8bit_addr();
-static void test_8bit_value_16bit_addr();
-static void test_16bit_value_16bit_addr();
-
 static vmcu_system_t* common(uint16_t addr, int16_t value);
-
-void test_compile_tac_store() {
-
-	test_8bit_value_8bit_addr();
-	test_16bit_value_8bit_addr();
-	test_8bit_value_16bit_addr();
-	test_16bit_value_16bit_addr();
-}
 
 static vmcu_system_t* common(uint16_t addr, int16_t value) {
 
@@ -47,13 +34,13 @@ static vmcu_system_t* common(uint16_t addr, int16_t value) {
 	return system;
 }
 
-static void test_8bit_value_8bit_addr() {
+void test_compile_tac_store_case_8bit_value_8bit_addr() {
 
 	status_test_codegen("TAC_STORE (8 bit value, 8 bit addr)");
 
-	for (uint16_t addr = 0xc7; addr < 0xd7; addr++) {
+	for (uint16_t addr = 0xc7; addr < 0xcb; addr++) {
 
-		for (int8_t fixed_value = 1; fixed_value < 10; fixed_value++) {
+		for (int8_t fixed_value = 1; fixed_value < 3; fixed_value++) {
 
 			vmcu_system_t* system = common(addr, fixed_value);
 
@@ -66,13 +53,13 @@ static void test_8bit_value_8bit_addr() {
 	}
 }
 
-static void test_16bit_value_8bit_addr() {
+void test_compile_tac_store_case_16bit_value_8bit_addr() {
 
 	status_test_codegen("TAC_STORE (16 bit value, 8 bit addr)");
 
-	for (uint16_t addr = 0xc7; addr < 0xd7; addr++) {
+	for (uint16_t addr = 0xc7; addr < 0xcb; addr++) {
 
-		for (uint16_t fixed_value = 0x0f00; fixed_value < 0x0f0f; fixed_value++) {
+		for (uint16_t fixed_value = 0x0f00; fixed_value < 0x0f03; fixed_value++) {
 
 			vmcu_system_t* system = common(addr, fixed_value);
 
@@ -88,13 +75,13 @@ static void test_16bit_value_8bit_addr() {
 	}
 }
 
-static void test_8bit_value_16bit_addr() {
+void test_compile_tac_store_case_8bit_value_16bit_addr() {
 
 	status_test_codegen("TAC_STORE (8 bit value, 16 bit addr)");
 
 	const uint16_t addr = 1200;
 
-	for (int8_t fixed_value = 1; fixed_value < 10; fixed_value++) {
+	for (int8_t fixed_value = 1; fixed_value < 3; fixed_value++) {
 
 		vmcu_system_t* system = common(addr, fixed_value);
 
@@ -106,13 +93,13 @@ static void test_8bit_value_16bit_addr() {
 	}
 }
 
-static void test_16bit_value_16bit_addr() {
+void test_compile_tac_store_case_16bit_value_16bit_addr() {
 
 	status_test_codegen("TAC_STORE (16 bit value, 16 bit addr)");
 
 	const uint16_t addr = 1200;
 
-	for (uint16_t fixed_value = 0x0f00; fixed_value < 0x0f0f; fixed_value++) {
+	for (uint16_t fixed_value = 0x0f00; fixed_value < 0x0f03; fixed_value++) {
 
 		vmcu_system_t* system = common(addr, fixed_value);
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_store_const_addr.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_store_const_addr.c
@@ -19,7 +19,7 @@ void test_compile_tac_store_const_addr() {
 
 	status_test_codegen("TAC_STORE_CONST_ADDR");
 
-	for (uint16_t addr = 0x118; addr < 0x140; addr++) {
+	for (uint16_t addr = 0x118; addr < 0x140; addr += 5) {
 
 		const int8_t fixed_value = 0x44;
 

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_unary_op.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_unary_op.c
@@ -15,26 +15,7 @@
 
 #include "test_compile_tac.h"
 
-static void case_minus_8bit();
-static void case_minus_16bit();
-
-static void case_not();
-
-static void case_bitwise_neg_8bit();
-static void case_bitwise_neg_16bit();
-
-void test_compile_tac_unary_op() {
-
-	case_minus_8bit();
-	case_minus_16bit();
-
-	case_not();
-
-	case_bitwise_neg_8bit();
-	case_bitwise_neg_16bit();
-}
-
-static void case_minus_8bit() {
+void test_compile_tac_unary_op_case_minus_8bit() {
 
 	status_test_codegen("TAC_UNARY_OP - (8 bit)");
 
@@ -58,7 +39,7 @@ static void case_minus_8bit() {
 	}
 }
 
-static void case_minus_16bit() {
+void test_compile_tac_unary_op_case_minus_16bit() {
 
 	status_test_codegen("TAC_UNARY_OP - (16 bit)");
 
@@ -85,7 +66,7 @@ static void case_minus_16bit() {
 	}
 }
 
-static void case_not() {
+void test_compile_tac_unary_op_case_not() {
 
 	status_test_codegen("TAC_UNARY_OP !");
 
@@ -108,7 +89,7 @@ static void case_not() {
 	vmcu_system_dtor(system);
 }
 
-static void case_bitwise_neg_8bit() {
+void test_compile_tac_unary_op_case_bitwise_neg_8bit() {
 
 	status_test_codegen("TAC_UNARY_OP ~ (8 bit)");
 
@@ -133,7 +114,7 @@ static void case_bitwise_neg_8bit() {
 	}
 }
 
-static void case_bitwise_neg_16bit() {
+void test_compile_tac_unary_op_case_bitwise_neg_16bit() {
 
 	status_test_codegen("TAC_UNARY_OP ~ (16 bit)");
 

--- a/compiler/test/gen_tac/test_gen_tac.h
+++ b/compiler/test/gen_tac/test_gen_tac.h
@@ -5,17 +5,82 @@
 
 #include "libvmcu_utils/libvmcu_utils.h"
 
-void test_gen_tac_assignstmt();
-void test_gen_tac_massignstmt();
-void test_gen_tac_mdirect();
-void test_gen_tac_expr();
-void test_gen_tac_ifstmt();
-void test_gen_tac_whilestmt();
-void test_gen_tac_forstmt();
-void test_gen_tac_simplevar();
-void test_gen_tac_variable();
-void test_gen_tac_call();
-void test_gen_tac_structdecl();
+// assign stmt
+void test_gen_tac_assignstmt_case_local_int_8bit();
+void test_gen_tac_assignstmt_case_local_int_16bit();
+void test_gen_tac_assignstmt_case_local_struct();
+void test_gen_tac_assignstmt_case_local_array();
+
+// massign stmt
+void test_gen_tac_massignstmt_case_const_addr();
+void test_gen_tac_massignstmt_case_variable_addr();
+
+// mdirect
+void test_gen_tac_mdirect_case_const_addr();
+void test_gen_tac_mdirect_case_variable_addr();
+
+// expr
+void test_gen_tac_expr_plus();
+void test_gen_tac_expr_minus();
+void test_gen_tac_expr_mul();
+void test_gen_tac_expr_and();
+void test_gen_tac_expr_or();
+void test_gen_tac_expr_shift_left();
+void test_gen_tac_expr_shift_right();
+void test_gen_tac_expr_xor();
+void test_gen_tac_expr_lt_8bit();
+void test_gen_tac_expr_lt_16bit();
+void test_gen_tac_expr_gt_8bit();
+void test_gen_tac_expr_gt_16bit();
+void test_gen_tac_expr_eq_8bit();
+void test_gen_tac_expr_eq_16bit();
+void test_gen_tac_expr_neq_8bit();
+void test_gen_tac_expr_neq_16bit();
+
+// if stmt
+void test_gen_tac_ifstmt_no_else_true_8bit();
+void test_gen_tac_ifstmt_no_else_true_16bit();
+void test_gen_tac_ifstmt_no_else_false_8bit();
+void test_gen_tac_ifstmt_no_else_false_16bit();
+void test_gen_tac_ifstmt_with_else_true();
+void test_gen_tac_ifstmt_with_else_false();
+
+// while stmt
+void test_gen_tac_whilestmt_case_0_rounds();
+void test_gen_tac_whilestmt_case_1_rounds();
+void test_gen_tac_whilestmt_case_n_rounds();
+void test_gen_tac_whilestmt_case_1_rounds_break();
+void test_gen_tac_whilestmt_case_1_rounds_continue();
+
+// for stmt
+void test_gen_tac_forstmt_0_rounds();
+void test_gen_tac_forstmt_1_rounds();
+void test_gen_tac_forstmt_1_rounds_break();
+void test_gen_tac_forstmt_n_rounds();
+
+// simplevar
+void test_gen_tac_simplevar_case_no_index();
+void test_gen_tac_simplevar_case_1_index();
+void test_gen_tac_simplevar_case_2_index();
+
+// variable
+void test_gen_tac_variable_case_no_member_access();
+void test_gen_tac_variable_case_1_member_access();
+void test_gen_tac_variable_case_2_member_access();
+
+// call
+void test_gen_tac_call_case_no_args();
+void test_gen_tac_call_case_1_args_return();
+void test_gen_tac_call_case_1_args_write();
+void test_gen_tac_call_case_1_args_write_3fns();
+void test_gen_tac_call_case_2_args();
+
+// struct decl
+void test_gen_tac_structdecl_case_read_struct();
+void test_gen_tac_structdecl_case_write_struct();
+//local struct in stack frame
+//void test_gen_tac_structdecl_case_read_local_struct();
+//void test_gen_tac_structdecl_case_write_local_struct();
 
 void status_test_codegen_tac(char* msg);
 

--- a/compiler/test/gen_tac/test_gen_tac_assignstmt.c
+++ b/compiler/test/gen_tac/test_gen_tac_assignstmt.c
@@ -5,20 +5,7 @@
 
 #include "test_gen_tac.h"
 
-static void case_local_int_8bit();
-static void case_local_int_16bit();
-static void case_local_struct();
-static void case_local_array();
-
-void test_gen_tac_assignstmt() {
-
-	case_local_int_8bit();
-	case_local_int_16bit();
-	case_local_struct();
-	case_local_array();
-}
-
-static void case_local_int_8bit() {
+void test_gen_tac_assignstmt_case_local_int_8bit() {
 
 	status_test_codegen_tac("AssignStmt - local int (8 bit)");
 
@@ -40,7 +27,7 @@ static void case_local_int_8bit() {
 	vmcu_system_dtor(system);
 }
 
-static void case_local_int_16bit() {
+void test_gen_tac_assignstmt_case_local_int_16bit() {
 
 	status_test_codegen_tac("AssignStmt - local int (16 bit)");
 
@@ -64,7 +51,7 @@ static void case_local_int_16bit() {
 	vmcu_system_dtor(system);
 }
 
-static void case_local_struct() {
+void test_gen_tac_assignstmt_case_local_struct() {
 
 	status_test_codegen_tac("AssignStmt - local struct [TODO]");
 	return;
@@ -87,7 +74,7 @@ static void case_local_struct() {
 	vmcu_system_dtor(system);
 }
 
-static void case_local_array() {
+void test_gen_tac_assignstmt_case_local_array() {
 
 	status_test_codegen_tac("AssignStmt - local array");
 

--- a/compiler/test/gen_tac/test_gen_tac_call.c
+++ b/compiler/test/gen_tac/test_gen_tac_call.c
@@ -5,22 +5,7 @@
 
 #include "test_gen_tac.h"
 
-static void case_no_args();
-static void case_1_args_return();
-static void case_1_args_write();
-static void case_1_args_write_3fns();
-static void case_2_args();
-
-void test_gen_tac_call() {
-
-	case_no_args();
-	case_1_args_return();
-	case_1_args_write();
-	case_1_args_write_3fns();
-	case_2_args();
-}
-
-static void case_no_args() {
+void test_gen_tac_call_case_no_args() {
 
 	status_test_codegen_tac("Call - no args");
 
@@ -45,7 +30,7 @@ static void case_no_args() {
 	vmcu_system_dtor(system);
 }
 
-static void case_1_args_return() {
+void test_gen_tac_call_case_1_args_return() {
 
 	status_test_codegen_tac("Call - 1 args - return value");
 
@@ -70,7 +55,7 @@ static void case_1_args_return() {
 	vmcu_system_dtor(system);
 }
 
-static void case_1_args_write() {
+void test_gen_tac_call_case_1_args_write() {
 
 	status_test_codegen_tac("Call - 1 args - write to SRAM");
 
@@ -91,7 +76,7 @@ static void case_1_args_write() {
 	vmcu_system_dtor(system);
 }
 
-static void case_1_args_write_3fns() {
+void test_gen_tac_call_case_1_args_write_3fns() {
 
 	status_test_codegen_tac("Call - 1 args - write to SRAM - 3 functions");
 
@@ -114,7 +99,7 @@ static void case_1_args_write_3fns() {
 	vmcu_system_dtor(system);
 }
 
-static void case_2_args() {
+void test_gen_tac_call_case_2_args() {
 
 	status_test_codegen_tac("Call - 2 args");
 

--- a/compiler/test/gen_tac/test_gen_tac_expr.c
+++ b/compiler/test/gen_tac/test_gen_tac_expr.c
@@ -5,51 +5,12 @@
 
 #include "test_gen_tac.h"
 
-//test each operator with 2 random values
-static void test_gen_tac_expr_plus();
-static void test_gen_tac_expr_minus();
-static void test_gen_tac_expr_mul();
-static void test_gen_tac_expr_and();
-static void test_gen_tac_expr_or();
-static void test_gen_tac_expr_shift_left();
-static void test_gen_tac_expr_shift_right();
-static void test_gen_tac_expr_xor();
-static void test_gen_tac_expr_lt_8bit();
-static void test_gen_tac_expr_lt_16bit();
-static void test_gen_tac_expr_gt_8bit();
-static void test_gen_tac_expr_gt_16bit();
-static void test_gen_tac_expr_eq_8bit();
-static void test_gen_tac_expr_eq_16bit();
-static void test_gen_tac_expr_neq_8bit();
-static void test_gen_tac_expr_neq_16bit();
-
-void test_gen_tac_expr() {
-
-	test_gen_tac_expr_plus();
-	test_gen_tac_expr_minus();
-	test_gen_tac_expr_mul();
-	test_gen_tac_expr_and();
-	test_gen_tac_expr_or();
-	test_gen_tac_expr_shift_left();
-	test_gen_tac_expr_shift_right();
-	test_gen_tac_expr_xor();
-
-	test_gen_tac_expr_lt_8bit();
-	test_gen_tac_expr_lt_16bit();
-	test_gen_tac_expr_gt_8bit();
-	test_gen_tac_expr_gt_16bit();
-	test_gen_tac_expr_eq_8bit();
-	test_gen_tac_expr_eq_16bit();
-	test_gen_tac_expr_neq_8bit();
-	test_gen_tac_expr_neq_16bit();
-}
-
-static void test_gen_tac_expr_plus() {
+void test_gen_tac_expr_plus() {
 
 	status_test_codegen_tac("Expr +");
 
-	for (int8_t value1 = 0; value1 < 4; value1++) {
-		for (int8_t value2 = 0; value2 < 4; value2++) {
+	for (int8_t value1 = 0; value1 < 3; value1++) {
+		for (int8_t value2 = 0; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> int { int x = %d + %d; return x; }", value1, value2);
@@ -71,12 +32,12 @@ static void test_gen_tac_expr_plus() {
 	}
 }
 
-static void test_gen_tac_expr_minus() {
+void test_gen_tac_expr_minus() {
 
 	status_test_codegen_tac("Expr -");
 
-	for (int8_t value1 = 50; value1 < 55; value1++) {
-		for (int8_t value2 = 0; value2 < 10; value2++) {
+	for (int8_t value1 = 50; value1 < 53; value1++) {
+		for (int8_t value2 = 0; value2 < 3; value2++) {
 			const int8_t expected = value1 - value2;
 
 			char snippet[200];
@@ -98,14 +59,14 @@ static void test_gen_tac_expr_minus() {
 	}
 }
 
-static void test_gen_tac_expr_mul() {
+void test_gen_tac_expr_mul() {
+
+	status_test_codegen_tac("Expr * (SKIPPING, TODO: re-enable)");
 
 	return;
 
-	status_test_codegen_tac("Expr *");
-
-	for (int8_t value1 = 0; value1 < 5; value1++) {
-		for (int8_t value2 = 0; value2 < 5; value2++) {
+	for (int8_t value1 = 0; value1 < 3; value1++) {
+		for (int8_t value2 = 0; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> int { int x = %d * %d; return x; }", value1, value2);
@@ -126,12 +87,12 @@ static void test_gen_tac_expr_mul() {
 	}
 }
 
-static void test_gen_tac_expr_and() {
+void test_gen_tac_expr_and() {
 
 	status_test_codegen_tac("Expr &");
 
-	for (int8_t value1 = 0; value1 < 10; value1++) {
-		for (int8_t value2 = 0; value2 < 10; value2++) {
+	for (int8_t value1 = 0; value1 < 3; value1++) {
+		for (int8_t value2 = 0; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> int { int x = %d & %d; return x; }", value1, value2);
@@ -153,12 +114,12 @@ static void test_gen_tac_expr_and() {
 	}
 }
 
-static void test_gen_tac_expr_or() {
+void test_gen_tac_expr_or() {
 
 	status_test_codegen_tac("Expr |");
 
-	for (int8_t value1 = 0; value1 < 10; value1++) {
-		for (int8_t value2 = 0; value2 < 10; value2++) {
+	for (int8_t value1 = 0; value1 < 3; value1++) {
+		for (int8_t value2 = 0; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> int { int x = %d | %d; return x; }", value1, value2);
@@ -176,12 +137,12 @@ static void test_gen_tac_expr_or() {
 	}
 }
 
-static void test_gen_tac_expr_shift_left() {
+void test_gen_tac_expr_shift_left() {
 
 	status_test_codegen_tac("Expr <<");
 
-	for (int8_t value1 = 0; value1 < 10; value1++) {
-		for (int8_t value2 = 1; value2 < 5; value2++) {
+	for (int8_t value1 = 0; value1 < 3; value1++) {
+		for (int8_t value2 = 1; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> int { int x = %d << %d; return x; }", value1, value2);
@@ -200,12 +161,12 @@ static void test_gen_tac_expr_shift_left() {
 	}
 }
 
-static void test_gen_tac_expr_shift_right() {
+void test_gen_tac_expr_shift_right() {
 
 	status_test_codegen_tac("Expr >>");
 
-	for (int8_t value1 = 0; value1 < 10; value1++) {
-		for (int8_t value2 = 1; value2 < 5; value2++) {
+	for (int8_t value1 = 0; value1 < 3; value1++) {
+		for (int8_t value2 = 1; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> int { int x = %d >> %d; return x; }", value1, value2);
@@ -224,12 +185,12 @@ static void test_gen_tac_expr_shift_right() {
 	}
 }
 
-static void test_gen_tac_expr_xor() {
+void test_gen_tac_expr_xor() {
 
 	status_test_codegen_tac("Expr ^");
 
-	for (int8_t value1 = 0; value1 < 10; value1++) {
-		for (int8_t value2 = 0; value2 < 10; value2++) {
+	for (int8_t value1 = 0; value1 < 3; value1++) {
+		for (int8_t value2 = 0; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> int { int x = %d ^ %d; return x; }", value1, value2);
@@ -252,12 +213,12 @@ static void test_gen_tac_expr_xor() {
 	}
 }
 
-static void test_gen_tac_expr_lt_8bit() {
+void test_gen_tac_expr_lt_8bit() {
 
 	status_test_codegen_tac("Expr < (8 bit)");
 
-	for (uint8_t value1 = 0; value1 < 4; value1++) {
-		for (uint8_t value2 = 0; value2 < 4; value2++) {
+	for (uint8_t value1 = 0; value1 < 3; value1++) {
+		for (uint8_t value2 = 0; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> bool { bool x = %d < %d; return x; }", value1, value2);
@@ -276,12 +237,12 @@ static void test_gen_tac_expr_lt_8bit() {
 	}
 }
 
-static void test_gen_tac_expr_lt_16bit() {
+void test_gen_tac_expr_lt_16bit() {
 
 	status_test_codegen_tac("Expr < (16 bit)");
 
-	for (uint16_t value1 = 0x100; value1 < 0x104; value1++) {
-		for (uint16_t value2 = 0x100; value2 < 0x104; value2++) {
+	for (uint16_t value1 = 0x100; value1 < 0x103; value1++) {
+		for (uint16_t value2 = 0x100; value2 < 0x103; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> bool { bool x = %d < %d; return x; }", value1, value2);
@@ -300,12 +261,12 @@ static void test_gen_tac_expr_lt_16bit() {
 	}
 }
 
-static void test_gen_tac_expr_gt_8bit() {
+void test_gen_tac_expr_gt_8bit() {
 
 	status_test_codegen_tac("Expr > (8 bit)");
 
-	for (uint8_t value1 = 0; value1 < 4; value1++) {
-		for (uint8_t value2 = 0; value2 < 4; value2++) {
+	for (uint8_t value1 = 0; value1 < 3; value1++) {
+		for (uint8_t value2 = 0; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> bool { bool x = %d > %d; return x; }", value1, value2);
@@ -324,12 +285,12 @@ static void test_gen_tac_expr_gt_8bit() {
 	}
 }
 
-static void test_gen_tac_expr_gt_16bit() {
+void test_gen_tac_expr_gt_16bit() {
 
 	status_test_codegen_tac("Expr > (16 bit)");
 
-	for (uint16_t value1 = 0x100; value1 < 0x104; value1++) {
-		for (uint16_t value2 = 0x100; value2 < 0x104; value2++) {
+	for (uint16_t value1 = 0x100; value1 < 0x103; value1++) {
+		for (uint16_t value2 = 0x100; value2 < 0x103; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> bool { bool x = %d > %d; return x; }", value1, value2);
@@ -348,12 +309,12 @@ static void test_gen_tac_expr_gt_16bit() {
 	}
 }
 
-static void test_gen_tac_expr_eq_8bit() {
+void test_gen_tac_expr_eq_8bit() {
 
 	status_test_codegen_tac("Expr == (8 bit)");
 
-	for (uint8_t value1 = 0; value1 < 4; value1++) {
-		for (uint8_t value2 = 0; value2 < 4; value2++) {
+	for (uint8_t value1 = 0; value1 < 3; value1++) {
+		for (uint8_t value2 = 0; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> bool { bool x = %d == %d; return x; }", value1, value2);
@@ -372,12 +333,12 @@ static void test_gen_tac_expr_eq_8bit() {
 	}
 }
 
-static void test_gen_tac_expr_eq_16bit() {
+void test_gen_tac_expr_eq_16bit() {
 
 	status_test_codegen_tac("Expr == (16 bit)");
 
-	for (uint16_t value1 = 0x100; value1 < 0x104; value1++) {
-		for (uint16_t value2 = 0x100; value2 < 0x104; value2++) {
+	for (uint16_t value1 = 0x100; value1 < 0x103; value1++) {
+		for (uint16_t value2 = 0x100; value2 < 0x103; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> bool { bool x = %d == %d; return x; }", value1, value2);
@@ -396,12 +357,12 @@ static void test_gen_tac_expr_eq_16bit() {
 	}
 }
 
-static void test_gen_tac_expr_neq_8bit() {
+void test_gen_tac_expr_neq_8bit() {
 
 	status_test_codegen_tac("Expr != (8 bit)");
 
-	for (uint8_t value1 = 0; value1 < 4; value1++) {
-		for (uint8_t value2 = 0; value2 < 4; value2++) {
+	for (uint8_t value1 = 0; value1 < 3; value1++) {
+		for (uint8_t value2 = 0; value2 < 3; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> bool { bool x = %d != %d; return x; }", value1, value2);
@@ -422,12 +383,12 @@ static void test_gen_tac_expr_neq_8bit() {
 	}
 }
 
-static void test_gen_tac_expr_neq_16bit() {
+void test_gen_tac_expr_neq_16bit() {
 
 	status_test_codegen_tac("Expr != (16 bit)");
 
-	for (uint16_t value1 = 0x100; value1 < 0x104; value1++) {
-		for (uint16_t value2 = 0x100; value2 < 0x104; value2++) {
+	for (uint16_t value1 = 0x100; value1 < 0x103; value1++) {
+		for (uint16_t value2 = 0x100; value2 < 0x103; value2++) {
 
 			char snippet[200];
 			sprintf(snippet, "fn main() -> bool { bool x = %d != %d; return x; }", value1, value2);

--- a/compiler/test/gen_tac/test_gen_tac_forstmt.c
+++ b/compiler/test/gen_tac/test_gen_tac_forstmt.c
@@ -6,20 +6,7 @@
 
 #include "test_gen_tac.h"
 
-static void test_gen_tac_forstmt_0_rounds();
-static void test_gen_tac_forstmt_1_rounds();
-static void test_gen_tac_forstmt_1_rounds_break();
-static void test_gen_tac_forstmt_n_rounds();
-
-void test_gen_tac_forstmt() {
-
-	test_gen_tac_forstmt_0_rounds();
-	test_gen_tac_forstmt_1_rounds();
-	test_gen_tac_forstmt_1_rounds_break();
-	test_gen_tac_forstmt_n_rounds();
-}
-
-static void test_gen_tac_forstmt_0_rounds() {
+void test_gen_tac_forstmt_0_rounds() {
 
 	status_test_codegen_tac("ForStmt 0 rounds");
 
@@ -40,7 +27,7 @@ static void test_gen_tac_forstmt_0_rounds() {
 	vmcu_system_dtor(system);
 }
 
-static void test_gen_tac_forstmt_1_rounds() {
+void test_gen_tac_forstmt_1_rounds() {
 
 	status_test_codegen_tac("ForStmt 1 rounds");
 
@@ -63,7 +50,7 @@ static void test_gen_tac_forstmt_1_rounds() {
 	vmcu_system_dtor(system);
 }
 
-static void test_gen_tac_forstmt_1_rounds_break() {
+void test_gen_tac_forstmt_1_rounds_break() {
 
 	status_test_codegen_tac("ForStmt 1 rounds break");
 
@@ -86,7 +73,7 @@ static void test_gen_tac_forstmt_1_rounds_break() {
 	vmcu_system_dtor(system);
 }
 
-static void test_gen_tac_forstmt_n_rounds() {
+void test_gen_tac_forstmt_n_rounds() {
 
 	status_test_codegen_tac("ForStmt n rounds");
 

--- a/compiler/test/gen_tac/test_gen_tac_ifstmt.c
+++ b/compiler/test/gen_tac/test_gen_tac_ifstmt.c
@@ -5,29 +5,11 @@
 
 #include "test_gen_tac.h"
 
-static void test_gen_tac_ifstmt_no_else_true_8bit();
-static void test_gen_tac_ifstmt_no_else_true_16bit();
-static void test_gen_tac_ifstmt_no_else_false_8bit();
-static void test_gen_tac_ifstmt_no_else_false_16bit();
-static void test_gen_tac_ifstmt_with_else_true();
-static void test_gen_tac_ifstmt_with_else_false();
-
-void test_gen_tac_ifstmt() {
-
-	test_gen_tac_ifstmt_no_else_true_8bit();
-	test_gen_tac_ifstmt_no_else_true_16bit();
-	test_gen_tac_ifstmt_no_else_false_8bit();
-	test_gen_tac_ifstmt_no_else_false_16bit();
-
-	test_gen_tac_ifstmt_with_else_true();
-	test_gen_tac_ifstmt_with_else_false();
-}
-
-static void test_gen_tac_ifstmt_no_else_true_8bit() {
+void test_gen_tac_ifstmt_no_else_true_8bit() {
 
 	status_test_codegen_tac("IfStmt (no else) true (8 bit)");
 
-	for (int8_t value1 = 0; value1 < 20; value1++) {
+	for (int8_t value1 = 0; value1 < 5; value1++) {
 		const int8_t value2 = value1 + 0x11;
 		const int8_t value_true = 0x33;
 		const int8_t value_false = 0x22;
@@ -50,11 +32,11 @@ static void test_gen_tac_ifstmt_no_else_true_8bit() {
 	}
 }
 
-static void test_gen_tac_ifstmt_no_else_true_16bit() {
+void test_gen_tac_ifstmt_no_else_true_16bit() {
 
 	status_test_codegen_tac("IfStmt (no else) true (16 bit)");
 
-	for (uint16_t value1 = 0x0100; value1 < 0x0110; value1++) {
+	for (uint16_t value1 = 0x0100; value1 < 0x0105; value1++) {
 		const uint16_t value2 = value1 + 0x11;
 		const int8_t value_true = 0x33;
 		const int8_t value_false = 0x22;
@@ -75,11 +57,11 @@ static void test_gen_tac_ifstmt_no_else_true_16bit() {
 	}
 }
 
-static void test_gen_tac_ifstmt_no_else_false_8bit() {
+void test_gen_tac_ifstmt_no_else_false_8bit() {
 
 	status_test_codegen_tac("IfStmt (no else) false (8 bit)");
 
-	for (int8_t value1 = 0; value1 < 20; value1++) {
+	for (int8_t value1 = 0; value1 < 5; value1++) {
 		const int8_t value2 = value1 + 4;
 		const int8_t value_true = 0xab;
 		const int8_t value_false = 0xba;
@@ -102,11 +84,11 @@ static void test_gen_tac_ifstmt_no_else_false_8bit() {
 	}
 }
 
-static void test_gen_tac_ifstmt_no_else_false_16bit() {
+void test_gen_tac_ifstmt_no_else_false_16bit() {
 
 	status_test_codegen_tac("IfStmt (no else) false (16 bit)");
 
-	for (uint16_t value1 = 0x0100; value1 < 0x0110; value1++) {
+	for (uint16_t value1 = 0x0100; value1 < 0x0105; value1++) {
 		const uint16_t value2 = value1 + 4;
 		const uint8_t value_true = 0xab;
 		const uint8_t value_false = 0xba;
@@ -127,11 +109,11 @@ static void test_gen_tac_ifstmt_no_else_false_16bit() {
 	}
 }
 
-static void test_gen_tac_ifstmt_with_else_true() {
+void test_gen_tac_ifstmt_with_else_true() {
 
 	status_test_codegen_tac("IfStmt (with else) true");
 
-	for (int8_t value1 = 0; value1 < 20; value1++) {
+	for (int8_t value1 = 0; value1 < 5; value1++) {
 		const int8_t value2 = value1 + 5;
 		const int8_t value_true = 0xab;
 		const int8_t value_false = 0xba;
@@ -154,11 +136,11 @@ static void test_gen_tac_ifstmt_with_else_true() {
 	}
 }
 
-static void test_gen_tac_ifstmt_with_else_false() {
+void test_gen_tac_ifstmt_with_else_false() {
 
 	status_test_codegen_tac("IfStmt (with else) false");
 
-	for (int8_t value1 = 0; value1 < 20; value1++) {
+	for (int8_t value1 = 0; value1 < 5; value1++) {
 		const int8_t value2 = value1 + 3;
 		const int8_t value_true = 0xb;
 		const int8_t value_false = value_true + 1;

--- a/compiler/test/gen_tac/test_gen_tac_massignstmt.c
+++ b/compiler/test/gen_tac/test_gen_tac_massignstmt.c
@@ -5,20 +5,11 @@
 
 #include "test_gen_tac.h"
 
-static void case_const_addr();
-static void case_variable_addr();
-
-void test_gen_tac_massignstmt() {
-
-	case_const_addr();
-	case_variable_addr();
-}
-
-static void case_const_addr() {
+void test_gen_tac_massignstmt_case_const_addr() {
 
 	status_test_codegen_tac("MAssignStmt - const Address");
 
-	for (int8_t value = 0; value < 20; value++) {
+	for (int8_t value = 0; value < 5; value++) {
 
 		char snippet[200];
 		sprintf(snippet, "fn main() -> int { [0x100] = %d; return 0; }", value);
@@ -35,12 +26,12 @@ static void case_const_addr() {
 	}
 }
 
-static void case_variable_addr() {
+void test_gen_tac_massignstmt_case_variable_addr() {
 
 	status_test_codegen_tac("MAssignStmt - variable Address");
 
 	const uint8_t addr = 0xc7;
-	for (uint8_t offset = 0; offset < 10; offset++) {
+	for (uint8_t offset = 0; offset < 5; offset++) {
 
 		const int8_t value = 0x31;
 

--- a/compiler/test/gen_tac/test_gen_tac_mdirect.c
+++ b/compiler/test/gen_tac/test_gen_tac_mdirect.c
@@ -5,20 +5,11 @@
 
 #include "test_gen_tac.h"
 
-static void case_const_addr();
-static void case_variable_addr();
-
-void test_gen_tac_mdirect() {
-
-	case_const_addr();
-	case_variable_addr();
-}
-
-static void case_const_addr() {
+void test_gen_tac_mdirect_case_const_addr() {
 
 	status_test_codegen_tac("MDirect - const Address");
 
-	for (uint16_t address = 0x100; address < 0x110; address++) {
+	for (uint16_t address = 0x100; address < 0x105; address++) {
 		const int8_t value = 0x34;
 
 		char snippet[200];
@@ -47,13 +38,13 @@ static void case_const_addr() {
 	}
 }
 
-static void case_variable_addr() {
+void test_gen_tac_mdirect_case_variable_addr() {
 
 	status_test_codegen_tac("MDirect - variable Address");
 
 	//we need an address here which is small enough
 	//to fit into a register. 0xc7 is usable.
-	for (uint16_t address = 0xc7; address < 0xd7; address++) {
+	for (uint16_t address = 0xc7; address < 0xcb; address++) {
 
 		const int8_t value = 0x38;
 

--- a/compiler/test/gen_tac/test_gen_tac_simplevar.c
+++ b/compiler/test/gen_tac/test_gen_tac_simplevar.c
@@ -5,19 +5,7 @@
 
 #include "test_gen_tac.h"
 
-static void case_no_index();
-static void case_1_index();
-static void case_2_index();
-//static void case_n_index();
-
-void test_gen_tac_simplevar() {
-
-	case_no_index();
-	case_1_index();
-	case_2_index();
-}
-
-static void case_no_index() {
+void test_gen_tac_simplevar_case_no_index() {
 
 	status_test_codegen_tac("SimpleVar - no index");
 
@@ -41,7 +29,7 @@ static void case_no_index() {
 	vmcu_system_dtor(system);
 }
 
-static void case_1_index() {
+void test_gen_tac_simplevar_case_1_index() {
 
 	status_test_codegen_tac("SimpleVar - 1 index");
 
@@ -83,7 +71,7 @@ static void case_1_index() {
 	}
 }
 
-static void case_2_index() {
+void test_gen_tac_simplevar_case_2_index() {
 
 	status_test_codegen_tac("SimpleVar - 2 index");
 

--- a/compiler/test/gen_tac/test_gen_tac_structdecl.c
+++ b/compiler/test/gen_tac/test_gen_tac_structdecl.c
@@ -5,21 +5,7 @@
 
 #include "test_gen_tac.h"
 
-//local struct in stack frame
-//static void case_read_local_struct();
-//static void case_write_local_struct();
-
-//structs anywhere, referenced by pointer
-static void case_read_struct();
-static void case_write_struct();
-
-void test_gen_tac_structdecl() {
-
-	case_read_struct();
-	case_write_struct();
-}
-
-static void case_read_struct() {
+void test_gen_tac_structdecl_case_read_struct() {
 
 	status_test_codegen_tac("StructDecl - read struct");
 
@@ -43,7 +29,7 @@ static void case_read_struct() {
 	vmcu_system_dtor(system);
 }
 
-static void case_write_struct() {
+void test_gen_tac_structdecl_case_write_struct() {
 
 	status_test_codegen_tac("StructDecl - write struct");
 

--- a/compiler/test/gen_tac/test_gen_tac_variable.c
+++ b/compiler/test/gen_tac/test_gen_tac_variable.c
@@ -5,18 +5,7 @@
 
 #include "test_gen_tac.h"
 
-static void case_no_member_access();
-static void case_1_member_access();
-static void case_2_member_access();
-
-void test_gen_tac_variable() {
-
-	case_no_member_access();
-	case_1_member_access();
-	case_2_member_access();
-}
-
-static void case_no_member_access() {
+void test_gen_tac_variable_case_no_member_access() {
 
 	status_test_codegen_tac("Variable - no member access");
 
@@ -38,7 +27,7 @@ static void case_no_member_access() {
 	}
 }
 
-static void case_1_member_access() {
+void test_gen_tac_variable_case_1_member_access() {
 
 	status_test_codegen_tac("Variable - 1 member access");
 
@@ -65,7 +54,7 @@ static void case_1_member_access() {
 	}
 }
 
-static void case_2_member_access() {
+void test_gen_tac_variable_case_2_member_access() {
 
 	status_test_codegen_tac("Variable - 2 member access");
 

--- a/compiler/test/gen_tac/test_gen_tac_whilestmt.c
+++ b/compiler/test/gen_tac/test_gen_tac_whilestmt.c
@@ -5,22 +5,7 @@
 
 #include "test_gen_tac.h"
 
-static void case_0_rounds();
-static void case_1_rounds();
-static void case_n_rounds();
-static void case_1_rounds_break();
-static void case_1_rounds_continue();
-
-void test_gen_tac_whilestmt() {
-
-	case_0_rounds();
-	case_1_rounds();
-	case_n_rounds();
-	case_1_rounds_break();
-	case_1_rounds_continue();
-}
-
-static void case_0_rounds() {
+void test_gen_tac_whilestmt_case_0_rounds() {
 
 	status_test_codegen_tac("WhileStmt 0 rounds");
 
@@ -44,7 +29,7 @@ static void case_0_rounds() {
 	vmcu_system_dtor(system);
 }
 
-static void case_1_rounds() {
+void test_gen_tac_whilestmt_case_1_rounds() {
 
 	status_test_codegen_tac("WhileStmt 1 rounds");
 
@@ -69,11 +54,11 @@ static void case_1_rounds() {
 	}
 }
 
-static void case_n_rounds() {
+void test_gen_tac_whilestmt_case_n_rounds() {
 
 	status_test_codegen_tac("WhileStmt n rounds");
 
-	for (int8_t initial = 0; initial < 7; initial++) {
+	for (int8_t initial = 0; initial < 3; initial++) {
 		for (int8_t bound = initial; bound < initial + 4; bound++) {
 
 			char snippet[200];
@@ -95,7 +80,7 @@ static void case_n_rounds() {
 	}
 }
 
-static void case_1_rounds_break() {
+void test_gen_tac_whilestmt_case_1_rounds_break() {
 
 	status_test_codegen_tac("WhileStmt 1 rounds break");
 
@@ -120,7 +105,7 @@ static void case_1_rounds_break() {
 	}
 }
 
-static void case_1_rounds_continue() {
+void test_gen_tac_whilestmt_case_1_rounds_continue() {
 
 	status_test_codegen_tac("WhileStmt 1 rounds continue");
 

--- a/compiler/test/testcases.c
+++ b/compiler/test/testcases.c
@@ -51,27 +51,123 @@ void (*tests_avr_codegen[])() = {
     test_compile_tac_setup_sp,
 
     test_compile_tac_nop,
-    test_compile_tac_const_value,
+
+    //TAC_CONST_VALUE
+    test_compile_tac_const_value_test_8bit,
+    test_compile_tac_const_value_test_16bit,
 
     test_compile_tac_store_const_addr,
     test_compile_tac_load_const_addr,
 
-    test_compile_tac_binary_op_immediate,
-    test_compile_tac_unary_op,
-    test_compile_tac_binary_op,
+    //TAC_BINARY_OP_IMMEDIATE
+    test_compile_tac_binary_op_immediate_case_add_8bit,
+    test_compile_tac_binary_op_immediate_case_add_16bit,
+    test_compile_tac_binary_op_immediate_case_sub_8bit,
+    test_compile_tac_binary_op_immediate_case_sub_16bit,
+    test_compile_tac_binary_op_immediate_case_and_8bit,
+    test_compile_tac_binary_op_immediate_case_and_16bit,
+    test_compile_tac_binary_op_immediate_case_or_8bit,
+    test_compile_tac_binary_op_immediate_case_or_16bit,
+    test_compile_tac_binary_op_immediate_case_xor_8bit,
+    test_compile_tac_binary_op_immediate_case_xor_16bit,
+    test_compile_tac_binary_op_immediate_case_shift_left_8bit,
+    test_compile_tac_binary_op_immediate_case_shift_left_16bit,
+    test_compile_tac_binary_op_immediate_case_shift_right_8bit,
+    test_compile_tac_binary_op_immediate_case_shift_right_16bit,
 
+    // TAC_UNARY_OP
+    test_compile_tac_unary_op_case_minus_8bit,
+    test_compile_tac_unary_op_case_minus_16bit,
+    test_compile_tac_unary_op_case_not,
+    test_compile_tac_unary_op_case_bitwise_neg_8bit,
+    test_compile_tac_unary_op_case_bitwise_neg_16bit,
+
+    // TAC_BINARY_OP
+    test_compile_tac_binary_op_add_8bit,
+    test_compile_tac_binary_op_add_16bit,
+    test_compile_tac_binary_op_sub_8bit,
+    test_compile_tac_binary_op_sub_16bit,
+    test_compile_tac_binary_op_and_8bit,
+    test_compile_tac_binary_op_and_16bit,
+    test_compile_tac_binary_op_or_8bit,
+    test_compile_tac_binary_op_or_16bit,
+    test_compile_tac_binary_op_xor_8bit,
+    test_compile_tac_binary_op_xor_16bit,
+    test_compile_tac_binary_op_xor_mixed1,
+    test_compile_tac_binary_op_xor_mixed2,
+    test_compile_tac_binary_op_neq_true_8bit,
+    test_compile_tac_binary_op_neq_true_16bit,
+    test_compile_tac_binary_op_neq_false_8bit,
+    test_compile_tac_binary_op_neq_false_16bit,
+    test_compile_tac_binary_op_lt_true_8bit,
+    test_compile_tac_binary_op_lt_true_16bit,
+    test_compile_tac_binary_op_lt_false_8bit,
+    test_compile_tac_binary_op_lt_false_16bit,
+    test_compile_tac_binary_op_eq_true_8bit,
+    test_compile_tac_binary_op_eq_true_16bit,
+    test_compile_tac_binary_op_eq_false_8bit,
+    test_compile_tac_binary_op_eq_false_16bit,
+    test_compile_tac_binary_op_geq_true_8bit,
+    test_compile_tac_binary_op_geq_true_16bit,
+    test_compile_tac_binary_op_geq_false_8bit,
+    test_compile_tac_binary_op_geq_false_16bit,
+
+    // TAC_GOTO
     test_compile_tac_goto,
-    test_compile_tac_if_goto,
-    test_compile_tac_if_cmp_goto,
 
+    // TAC_IF_GOTO
+    test_compile_tac_if_goto_case_true_8bit,
+    test_compile_tac_if_goto_case_true_16bit,
+    test_compile_tac_if_goto_case_false_8bit,
+    test_compile_tac_if_goto_case_false_16bit,
+    test_compile_tac_if_goto_case_mixed,
+
+    // TAC_IF_CMP_GOTO
+    test_compile_tac_if_cmp_goto_case_eq_true_8bit,
+    test_compile_tac_if_cmp_goto_case_eq_true_16bit,
+    test_compile_tac_if_cmp_goto_case_eq_false_8bit,
+    test_compile_tac_if_cmp_goto_case_eq_false_16bit,
+    test_compile_tac_if_cmp_goto_case_neq_true_8bit,
+    test_compile_tac_if_cmp_goto_case_neq_true_16bit,
+    test_compile_tac_if_cmp_goto_case_neq_false_8bit,
+    test_compile_tac_if_cmp_goto_case_neq_false_16bit,
+    test_compile_tac_if_cmp_goto_case_lt_true_8bit,
+    test_compile_tac_if_cmp_goto_case_lt_true_16bit,
+    test_compile_tac_if_cmp_goto_case_lt_false_8bit,
+    test_compile_tac_if_cmp_goto_case_lt_false_16bit,
+    test_compile_tac_if_cmp_goto_case_ge_true_8bit,
+    test_compile_tac_if_cmp_goto_case_ge_true_16bit,
+    test_compile_tac_if_cmp_goto_case_ge_false_8bit,
+    test_compile_tac_if_cmp_goto_case_ge_false_16bit,
+
+    // TAC_RETURN
     test_compile_tac_return,
-    test_compile_tac_copy,
-    test_compile_tac_param,
-    test_compile_tac_call,
+
+    // TAC_COPY
+    test_compile_tac_copy_case_8bit,
+    test_compile_tac_copy_case_16bit,
+
+    // TAC_PARAM
+    test_compile_tac_param_case_8bit,
+    test_compile_tac_param_case_16bit,
+
+    // TAC_CALL
+    test_compile_tac_call_case_recurses,
+    test_compile_tac_call_case_returns_value,
+    test_compile_tac_call_case_1_param,
+
+    // TAC_SETUP_STACKFRAME
     test_compile_tac_setup_stackframe,
 
-    test_compile_tac_load,
-    test_compile_tac_store,
+    // TAC_LOAD
+    test_compile_tac_load_case_8bit_addr,
+    test_compile_tac_load_case_16bit_addr,
+
+    // TAC_STORE
+    test_compile_tac_store_case_8bit_value_8bit_addr,
+    test_compile_tac_store_case_16bit_value_8bit_addr,
+    test_compile_tac_store_case_8bit_value_16bit_addr,
+    test_compile_tac_store_case_16bit_value_16bit_addr,
 
     //test AVR Codegen as it relates to internal timers
     test_avr_code_gen_timer,
@@ -79,48 +175,168 @@ void (*tests_avr_codegen[])() = {
 };
 
 void (*tests_tac_codegen[])() = {
-    test_gen_tac_mdirect,
-    test_gen_tac_assignstmt,
-    test_gen_tac_massignstmt,
-    test_gen_tac_expr,
+    // mdirect
+    test_gen_tac_mdirect_case_const_addr,
+    test_gen_tac_mdirect_case_variable_addr,
 
-    test_gen_tac_ifstmt,
-    test_gen_tac_whilestmt,
-    test_gen_tac_forstmt,
+    // assign stmt
+    test_gen_tac_assignstmt_case_local_int_8bit,
+    test_gen_tac_assignstmt_case_local_int_16bit,
+    test_gen_tac_assignstmt_case_local_struct,
+    test_gen_tac_assignstmt_case_local_array,
 
-    test_gen_tac_simplevar,
-    test_gen_tac_variable,
+    // massign stmt
+    test_gen_tac_massignstmt_case_const_addr,
+    test_gen_tac_massignstmt_case_variable_addr,
 
-    test_gen_tac_call,
-    test_gen_tac_structdecl,
+    // expr
+    test_gen_tac_expr_plus,
+    test_gen_tac_expr_minus,
+    test_gen_tac_expr_mul,
+    test_gen_tac_expr_and,
+    test_gen_tac_expr_or,
+    test_gen_tac_expr_shift_left,
+    test_gen_tac_expr_shift_right,
+    test_gen_tac_expr_xor,
+    test_gen_tac_expr_lt_8bit,
+    test_gen_tac_expr_lt_16bit,
+    test_gen_tac_expr_gt_8bit,
+    test_gen_tac_expr_gt_16bit,
+    test_gen_tac_expr_eq_8bit,
+    test_gen_tac_expr_eq_16bit,
+    test_gen_tac_expr_neq_8bit,
+    test_gen_tac_expr_neq_16bit,
+
+    // if stmt
+    test_gen_tac_ifstmt_no_else_true_8bit,
+    test_gen_tac_ifstmt_no_else_true_16bit,
+    test_gen_tac_ifstmt_no_else_false_8bit,
+    test_gen_tac_ifstmt_no_else_false_16bit,
+    test_gen_tac_ifstmt_with_else_true,
+    test_gen_tac_ifstmt_with_else_false,
+
+    // while stmt
+    test_gen_tac_whilestmt_case_0_rounds,
+    test_gen_tac_whilestmt_case_1_rounds,
+    test_gen_tac_whilestmt_case_n_rounds,
+    test_gen_tac_whilestmt_case_1_rounds_break,
+    test_gen_tac_whilestmt_case_1_rounds_continue,
+
+    // for stmt
+    test_gen_tac_forstmt_0_rounds,
+    test_gen_tac_forstmt_1_rounds,
+    test_gen_tac_forstmt_1_rounds_break,
+    test_gen_tac_forstmt_n_rounds,
+
+    // simple var
+    test_gen_tac_simplevar_case_no_index,
+    test_gen_tac_simplevar_case_1_index,
+    test_gen_tac_simplevar_case_2_index,
+
+    // variable
+    test_gen_tac_variable_case_no_member_access,
+    test_gen_tac_variable_case_1_member_access,
+    test_gen_tac_variable_case_2_member_access,
+
+    // call
+    test_gen_tac_call_case_no_args,
+    test_gen_tac_call_case_1_args_return,
+    test_gen_tac_call_case_1_args_write,
+    test_gen_tac_call_case_1_args_write_3fns,
+    test_gen_tac_call_case_2_args,
+
+    // struct decl
+    test_gen_tac_structdecl_case_read_struct,
+    test_gen_tac_structdecl_case_write_struct,
+
     NULL,
 };
 
 void (*tests_x86_codegen[])() = {
+    //TAC_NOP
     test_x86_compile_tac_nop,
+
+    //TAC_CONST_VALUE
     test_x86_compile_tac_const_value,
 
+    //TAC_STORE_CONST_ADDR
     test_x86_compile_tac_store_const_addr,
+
+    //TAC_LOAD_CONST_ADDR
     test_x86_compile_tac_load_const_addr,
 
-    test_x86_compile_tac_binary_op_immediate,
-    test_x86_compile_tac_unary_op,
-    test_x86_compile_tac_binary_op,
+    //TAC_BINARY_OP_IMMEDIATE
+    test_x86_compile_tac_binary_op_immediate_case_add,
+    test_x86_compile_tac_binary_op_immediate_case_sub,
+    test_x86_compile_tac_binary_op_immediate_case_and,
+    test_x86_compile_tac_binary_op_immediate_case_or,
+    test_x86_compile_tac_binary_op_immediate_case_xor,
+    test_x86_compile_tac_binary_op_immediate_case_shift_left,
+    test_x86_compile_tac_binary_op_immediate_case_shift_right,
 
+    //TAC_UNARY_OP
+    test_x86_compile_tac_unary_op_case_minus,
+    test_x86_compile_tac_unary_op_case_not,
+    test_x86_compile_tac_unary_op_case_bitwise_neg,
+
+    //TAC_BINARY_OP
+    test_x86_compile_tac_binary_op_add_8bit,
+    test_x86_compile_tac_binary_op_sub_8bit,
+    test_x86_compile_tac_binary_op_and_8bit,
+    test_x86_compile_tac_binary_op_or_8bit,
+    test_x86_compile_tac_binary_op_xor,
+    test_x86_compile_tac_binary_op_neq_true_8bit,
+    test_x86_compile_tac_binary_op_neq_false_8bit,
+    test_x86_compile_tac_binary_op_lt_true_8bit,
+    test_x86_compile_tac_binary_op_lt_false_8bit,
+    test_x86_compile_tac_binary_op_eq_true_8bit,
+    test_x86_compile_tac_binary_op_eq_false_8bit,
+    test_x86_compile_tac_binary_op_geq_true_8bit,
+    test_x86_compile_tac_binary_op_geq_false_8bit,
+
+    //TAC_GOTO
     test_x86_compile_tac_goto,
-    test_x86_compile_tac_if_goto,
-    test_x86_compile_tac_if_cmp_goto,
 
+    //TAC_IF_GOTO
+    test_x86_compile_tac_if_goto_case_true,
+    test_x86_compile_tac_if_goto_case_false,
+    test_x86_compile_tac_if_goto_case_mixed,
+
+    //TAC_IF_CMP_GOTO
+    test_x86_compile_tac_if_cmp_goto_case_eq_true_8bit,
+    test_x86_compile_tac_if_cmp_goto_case_eq_false_8bit,
+    test_x86_compile_tac_if_cmp_goto_case_neq_true_8bit,
+    test_x86_compile_tac_if_cmp_goto_case_neq_false_8bit,
+    test_x86_compile_tac_if_cmp_goto_case_lt_true_8bit,
+    test_x86_compile_tac_if_cmp_goto_case_lt_false_8bit,
+    test_x86_compile_tac_if_cmp_goto_case_ge_true_8bit,
+    test_x86_compile_tac_if_cmp_goto_case_ge_false_8bit,
+
+    //TAC_RETURN
     test_x86_compile_tac_return,
+
+    //TAC_COPY
     test_x86_compile_tac_copy,
+
+    //TAC_PARAM
     test_x86_compile_tac_param,
+
+    //TAC_CALL
     //test_x86_compile_tac_call,
+
+    //TAC_SETUP_STACKFRAME
     //test_x86_compile_tac_setup_stackframe,
 
+    //TAC_LOAD
     test_x86_compile_tac_load,
+
+    //TAC_STORE
     test_x86_compile_tac_store,
 
+    //TAC_LOAD_LOCAL
     test_x86_compile_tac_load_local,
+
+    //TAC_STORE_LOCAL
     test_x86_compile_tac_store_local,
     NULL,
 };

--- a/compiler/test/x86_code_gen/compile_ir/test_compile_tac.h
+++ b/compiler/test/x86_code_gen/compile_ir/test_compile_tac.h
@@ -16,15 +16,49 @@ void test_x86_compile_tac_load_const_addr();
 
 void test_x86_compile_tac_load();
 
-void test_x86_compile_tac_unary_op();
+//TAC_UNARY_OP
+void test_x86_compile_tac_unary_op_case_minus();
+void test_x86_compile_tac_unary_op_case_not();
+void test_x86_compile_tac_unary_op_case_bitwise_neg();
 
-void test_x86_compile_tac_binary_op();
+//TAC_BINARY_OP
+void test_x86_compile_tac_binary_op_add_8bit();
+void test_x86_compile_tac_binary_op_sub_8bit();
+void test_x86_compile_tac_binary_op_and_8bit();
+void test_x86_compile_tac_binary_op_or_8bit();
+void test_x86_compile_tac_binary_op_xor();
+void test_x86_compile_tac_binary_op_neq_true_8bit();
+void test_x86_compile_tac_binary_op_neq_false_8bit();
+void test_x86_compile_tac_binary_op_lt_true_8bit();
+void test_x86_compile_tac_binary_op_lt_false_8bit();
+void test_x86_compile_tac_binary_op_eq_true_8bit();
+void test_x86_compile_tac_binary_op_eq_false_8bit();
+void test_x86_compile_tac_binary_op_geq_true_8bit();
+void test_x86_compile_tac_binary_op_geq_false_8bit();
 
-void test_x86_compile_tac_binary_op_immediate();
+//TAC_BINARY_OP_IMMEDIATE
+void test_x86_compile_tac_binary_op_immediate_case_add();
+void test_x86_compile_tac_binary_op_immediate_case_sub();
+void test_x86_compile_tac_binary_op_immediate_case_and();
+void test_x86_compile_tac_binary_op_immediate_case_or();
+void test_x86_compile_tac_binary_op_immediate_case_xor();
+void test_x86_compile_tac_binary_op_immediate_case_shift_left();
+void test_x86_compile_tac_binary_op_immediate_case_shift_right();
 
-void test_x86_compile_tac_if_cmp_goto();
+//TAC_IF_CMP_GOTO
+void test_x86_compile_tac_if_cmp_goto_case_eq_true_8bit();
+void test_x86_compile_tac_if_cmp_goto_case_eq_false_8bit();
+void test_x86_compile_tac_if_cmp_goto_case_neq_true_8bit();
+void test_x86_compile_tac_if_cmp_goto_case_neq_false_8bit();
+void test_x86_compile_tac_if_cmp_goto_case_lt_true_8bit();
+void test_x86_compile_tac_if_cmp_goto_case_lt_false_8bit();
+void test_x86_compile_tac_if_cmp_goto_case_ge_true_8bit();
+void test_x86_compile_tac_if_cmp_goto_case_ge_false_8bit();
 
-void test_x86_compile_tac_if_goto();
+//TAC_IF_GOTO
+void test_x86_compile_tac_if_goto_case_true();
+void test_x86_compile_tac_if_goto_case_false();
+void test_x86_compile_tac_if_goto_case_mixed();
 
 void test_x86_compile_tac_load_local();
 

--- a/compiler/test/x86_code_gen/compile_ir/test_compile_tac_binary_op.c
+++ b/compiler/test/x86_code_gen/compile_ir/test_compile_tac_binary_op.c
@@ -12,67 +12,13 @@
 
 #include "test_compile_tac.h"
 
-static void test_compile_tac_binary_op_add_8bit();
-static void test_compile_tac_binary_op_sub_8bit();
-static void test_compile_tac_binary_op_and_8bit();
-static void test_compile_tac_binary_op_or_8bit();
-
-static void test_compile_tac_binary_op_xor_8bit();
-static void test_compile_tac_binary_op_xor_mixed1();
-static void test_compile_tac_binary_op_xor_mixed2();
-
-static void test_compile_tac_binary_op_neq_true_8bit();
-
-static void test_compile_tac_binary_op_neq_false_8bit();
-
-static void test_compile_tac_binary_op_lt_true_8bit();
-
-static void test_compile_tac_binary_op_lt_false_8bit();
-
-static void test_compile_tac_binary_op_eq_true_8bit();
-
-static void test_compile_tac_binary_op_eq_false_8bit();
-
-static void test_compile_tac_binary_op_geq_true_8bit();
-static void test_compile_tac_binary_op_geq_false_8bit();
-
-void test_x86_compile_tac_binary_op() {
-
-	test_compile_tac_binary_op_add_8bit();
-
-	test_compile_tac_binary_op_sub_8bit();
-
-	test_compile_tac_binary_op_and_8bit();
-
-	test_compile_tac_binary_op_or_8bit();
-
-	test_compile_tac_binary_op_xor_8bit();
-	test_compile_tac_binary_op_xor_mixed1();
-	test_compile_tac_binary_op_xor_mixed2();
-
-	test_compile_tac_binary_op_neq_true_8bit();
-
-	test_compile_tac_binary_op_neq_false_8bit();
-
-	test_compile_tac_binary_op_lt_true_8bit();
-
-	test_compile_tac_binary_op_lt_false_8bit();
-
-	test_compile_tac_binary_op_eq_true_8bit();
-
-	test_compile_tac_binary_op_eq_false_8bit();
-
-	test_compile_tac_binary_op_geq_true_8bit();
-	test_compile_tac_binary_op_geq_false_8bit();
-}
-
-static void test_compile_tac_binary_op_add_8bit() {
+void test_x86_compile_tac_binary_op_add_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP +");
 
 	const int8_t start = 0x01;
 
-	for (int8_t change = 0; change < 100; change += 10) {
+	for (int8_t change = 0; change < 3; change++) {
 
 		const int8_t expected = start + change;
 
@@ -97,12 +43,12 @@ static void test_compile_tac_binary_op_add_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_sub_8bit() {
+void test_x86_compile_tac_binary_op_sub_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP -");
 
 	int8_t start = 0;
-	for (int8_t change = -10; change < 100; change += 10) {
+	for (int8_t change = -2; change < 2; change++) {
 
 		int8_t expected = start - change;
 
@@ -127,12 +73,12 @@ static void test_compile_tac_binary_op_sub_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_and_8bit() {
+void test_x86_compile_tac_binary_op_and_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP &");
 
 	uint8_t start = 0x45;
-	for (uint8_t change = 0xf0; change < 0xfe; change++) {
+	for (uint8_t change = 0xf0; change < 0xf3; change++) {
 
 		int8_t expected = start & change;
 
@@ -157,12 +103,12 @@ static void test_compile_tac_binary_op_and_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_or_8bit() {
+void test_x86_compile_tac_binary_op_or_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP |");
 
 	int8_t start = 0xab;
-	for (int8_t change = 0x30; change < 0x40; change++) {
+	for (int8_t change = 0x30; change < 0x33; change++) {
 
 		int8_t expected = start | change;
 
@@ -187,14 +133,12 @@ static void test_compile_tac_binary_op_or_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_xor_8bit() {
+void test_x86_compile_tac_binary_op_xor() {
 
 	status_test_x86_codegen("TAC_BINARY_OP ^");
 
-	uint8_t start = 0xab;
-	for (uint8_t change = 0xf0; change < 0xff; change++) {
-		int8_t expected = start ^ change;
-
+	uint64_t start = 0xab;
+	for (uint64_t change = 0xf0; change < 0xf3; change++) {
 		struct TACBuffer* b = tacbuffer_ctor();
 
 		tacbuffer_append(b, makeTACConst(0, start));
@@ -210,75 +154,17 @@ static void test_compile_tac_binary_op_xor_8bit() {
 		uint64_t rax = 0;
 		sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
 
-		assert(rax == expected);
+		assert(rax == (start ^ change));
 
 		sd_uc_close(system);
 	}
 }
 
-static void test_compile_tac_binary_op_xor_mixed1() {
-
-	status_test_x86_codegen("TAC_BINARY_OP ^ (mixed1, 8bit, 16bit)");
-
-	const uint16_t start = 0x00ff;
-	const uint16_t change = 0xffff;
-
-	struct TACBuffer* b = tacbuffer_ctor();
-
-	tacbuffer_append(b, makeTACConst(0, start));
-	tacbuffer_append(b, makeTACConst(1, change));
-	tacbuffer_append(b, makeTACBinOp(0, TAC_OP_XOR, 1));
-
-	tacbuffer_append(b, makeTACReturn(0));
-
-	struct sd_uc_engine* system = sd_uc_engine_from_tacbuffer_v2(b, false);
-
-	sd_uc_emu_start(system, 0, false);
-
-	uint64_t rax = 0;
-	sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
-
-	assert(rax == 0xff00);
-
-	sd_uc_close(system);
-}
-
-static void test_compile_tac_binary_op_xor_mixed2() {
-
-	status_test_x86_codegen("TAC_BINARY_OP ^ (mixed2, 16bit, 8bit)");
-
-	const uint16_t start = 0xabcd;
-
-	for (uint16_t change = 0x1000; change < 0x1010; change++) {
-
-		const uint16_t expected = start ^ change;
-
-		struct TACBuffer* b = tacbuffer_ctor();
-
-		tacbuffer_append(b, makeTACConst(0, start));
-		tacbuffer_append(b, makeTACConst(1, change));
-		tacbuffer_append(b, makeTACBinOp(0, TAC_OP_XOR, 1));
-
-		tacbuffer_append(b, makeTACReturn(0));
-
-		struct sd_uc_engine* system = sd_uc_engine_from_tacbuffer_v2(b, false);
-
-		sd_uc_emu_start(system, 0, false);
-
-		uint64_t rax = 0;
-		sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
-
-		assert(rax == expected);
-
-		sd_uc_close(system);
-	}
-}
-
-static void test_compile_tac_binary_op_neq_true_8bit() {
+void test_x86_compile_tac_binary_op_neq_true_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP != true");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 
 		int8_t value2 = value1 + 1;
 
@@ -303,11 +189,11 @@ static void test_compile_tac_binary_op_neq_true_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_neq_false_8bit() {
+void test_x86_compile_tac_binary_op_neq_false_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP != false");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 
 		int8_t value2 = value1;
 
@@ -332,11 +218,11 @@ static void test_compile_tac_binary_op_neq_false_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_lt_true_8bit() {
+void test_x86_compile_tac_binary_op_lt_true_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP < true");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 
 		int8_t value2 = value1 + 1;
 
@@ -361,11 +247,11 @@ static void test_compile_tac_binary_op_lt_true_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_lt_false_8bit() {
+void test_x86_compile_tac_binary_op_lt_false_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP < false");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 		int8_t value2 = value1;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -389,11 +275,11 @@ static void test_compile_tac_binary_op_lt_false_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_eq_true_8bit() {
+void test_x86_compile_tac_binary_op_eq_true_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP == true");
 
-	for (int8_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (int8_t value1 = 0x0; value1 < 0x3; value1++) {
 		int8_t value2 = value1;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -420,11 +306,11 @@ static void test_compile_tac_binary_op_eq_true_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_eq_false_8bit() {
+void test_x86_compile_tac_binary_op_eq_false_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP == false");
 
-	for (uint64_t value1 = 0x0; value1 < 0xf; value1++) {
+	for (uint64_t value1 = 0x0; value1 < 0x3; value1++) {
 		uint64_t value2 = value1 + 1;
 
 		struct TACBuffer* b = tacbuffer_ctor();
@@ -451,11 +337,11 @@ static void test_compile_tac_binary_op_eq_false_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_geq_true_8bit() {
+void test_x86_compile_tac_binary_op_geq_true_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP >= true");
 
-	for (uint8_t value1 = 0x03; value1 < 0x0f; value1++) {
+	for (uint8_t value1 = 0x03; value1 < 0x06; value1++) {
 
 		uint8_t value2 = 0x03;
 
@@ -480,11 +366,11 @@ static void test_compile_tac_binary_op_geq_true_8bit() {
 	}
 }
 
-static void test_compile_tac_binary_op_geq_false_8bit() {
+void test_x86_compile_tac_binary_op_geq_false_8bit() {
 
 	status_test_x86_codegen("TAC_BINARY_OP >= false");
 
-	for (uint8_t value1 = 0x03; value1 < 0x0f; value1++) {
+	for (uint8_t value1 = 0x03; value1 < 0x06; value1++) {
 
 		uint8_t value2 = 0x10;
 

--- a/compiler/test/x86_code_gen/compile_ir/test_compile_tac_binary_op_immediate.c
+++ b/compiler/test/x86_code_gen/compile_ir/test_compile_tac_binary_op_immediate.c
@@ -12,34 +12,13 @@
 
 #include "test_compile_tac.h"
 
-static void case_add();
-static void case_sub();
-static void case_and();
-static void case_or();
-static void case_xor();
-static void case_shift_left();
-static void case_shift_right();
-
-void test_x86_compile_tac_binary_op_immediate() {
-
-	case_add();
-	case_sub();
-	case_and();
-	case_or();
-	case_xor();
-	case_shift_left();
-	case_shift_right();
-}
-
-static void case_add() {
+void test_x86_compile_tac_binary_op_immediate_case_add() {
 
 	status_test_x86_codegen("TAC_BINARY_OP_IMMEDIATE +");
 
 	int8_t start = 0x83;
 
-	for (uint8_t change = 0; change < 20; change++) {
-
-		int8_t expected = start + change;
+	for (uint8_t change = 0; change < 5; change++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -55,21 +34,19 @@ static void case_add() {
 		uint64_t rax = 0;
 		sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
 
-		assert(rax == expected);
+		assert(rax == (start + change));
 
 		sd_uc_close(system);
 	}
 }
 
-static void case_sub() {
+void test_x86_compile_tac_binary_op_immediate_case_sub() {
 
 	status_test_x86_codegen("TAC_BINARY_OP_IMMEDIATE -");
 
 	int8_t start = 44;
 
-	for (uint8_t change = 0; change < 20; change++) {
-
-		const int8_t expected = start - change;
+	for (uint8_t change = 0; change < 5; change++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -85,19 +62,18 @@ static void case_sub() {
 		uint64_t rax = 0;
 		sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
 
-		assert(rax == expected);
+		assert(rax == (start - change));
 
 		sd_uc_close(system);
 	}
 }
 
-static void case_and() {
+void test_x86_compile_tac_binary_op_immediate_case_and() {
 
 	status_test_x86_codegen("TAC_BINARY_OP_IMMEDIATE &");
 
 	int8_t start = 0xe3;
-	for (int8_t change = 0; change < 10; change++) {
-		int8_t expected = start & change;
+	for (int8_t change = 0; change < 5; change++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -112,19 +88,18 @@ static void case_and() {
 		uint64_t rax = 0;
 		sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
 
-		assert(rax == expected);
+		assert(rax == (start & change));
 
 		sd_uc_close(system);
 	}
 }
 
-static void case_or() {
+void test_x86_compile_tac_binary_op_immediate_case_or() {
 
 	status_test_x86_codegen("TAC_BINARY_OP_IMMEDIATE |");
 
 	int8_t start = 0xc7;
-	for (int8_t change = 0; change < 10; change++) {
-		int8_t expected = start | change;
+	for (int8_t change = 0; change < 5; change++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -139,19 +114,18 @@ static void case_or() {
 		uint64_t rax = 0;
 		sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
 
-		assert(rax == expected);
+		assert(rax == (start | change));
 
 		sd_uc_close(system);
 	}
 }
 
-static void case_xor() {
+void test_x86_compile_tac_binary_op_immediate_case_xor() {
 
 	status_test_x86_codegen("TAC_BINARY_OP_IMMEDIATE ^");
 
 	int8_t start = 0xc3;
-	for (int8_t change = 0; change < 10; change++) {
-		int8_t expected = start ^ change;
+	for (int8_t change = 0; change < 5; change++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -166,21 +140,19 @@ static void case_xor() {
 		uint64_t rax = 0;
 		sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
 
-		assert(rax == expected);
+		assert(rax == (start ^ change));
 
 		sd_uc_close(system);
 	}
 }
 
-static void case_shift_left() {
+void test_x86_compile_tac_binary_op_immediate_case_shift_left() {
 
 	status_test_x86_codegen("TAC_BINARY_OP_IMMEDIATE <<");
 
 	uint64_t start = 0xb3;
 
 	for (int change = 1; change < 6; change++) {
-
-		const uint64_t expected = start << change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -195,21 +167,19 @@ static void case_shift_left() {
 		uint64_t rax = 0;
 		sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
 
-		assert(rax == expected);
+		assert(rax == (start << change));
 
 		sd_uc_close(system);
 	}
 }
 
-static void case_shift_right() {
+void test_x86_compile_tac_binary_op_immediate_case_shift_right() {
 
 	status_test_x86_codegen("TAC_BINARY_OP_IMMEDIATE >>");
 
 	uint64_t start = 0xb4;
 
 	for (int change = 1; change < 6; change++) {
-
-		const uint64_t expected = start >> change;
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -224,7 +194,7 @@ static void case_shift_right() {
 		uint64_t rax = 0;
 		sd_uc_reg_read(system, UC_X86_REG_RAX, &rax);
 
-		assert(rax == expected);
+		assert(rax == (start >> change));
 
 		sd_uc_close(system);
 	}

--- a/compiler/test/x86_code_gen/compile_ir/test_compile_tac_const_value.c
+++ b/compiler/test/x86_code_gen/compile_ir/test_compile_tac_const_value.c
@@ -20,9 +20,9 @@ void test_x86_compile_tac_const_value() {
 
 	status_test_x86_codegen("TAC_CONST_VALUE");
 
-	for (int8_t fixed_value = -100; fixed_value < 100; fixed_value += 10) {
+	for (int8_t fixed_value = -2; fixed_value <= 2; fixed_value++) {
 
-		test_x86_compile_tac_const_value_fixed_value(fixed_value);
+		test_x86_compile_tac_const_value_fixed_value(fixed_value * 10);
 	}
 }
 

--- a/compiler/test/x86_code_gen/compile_ir/test_compile_tac_if_cmp_goto.c
+++ b/compiler/test/x86_code_gen/compile_ir/test_compile_tac_if_cmp_goto.c
@@ -12,31 +12,7 @@
 
 #include "test_compile_tac.h"
 
-static void case_eq_true_8bit();
-static void case_eq_false_8bit();
-static void case_neq_true_8bit();
-static void case_neq_false_8bit();
-static void case_lt_true_8bit();
-static void case_lt_false_8bit();
-static void case_ge_true_8bit();
-static void case_ge_false_8bit();
-
 static void common(int a, enum TAC_OP op, int b, bool expect_true, bool debug);
-
-void test_x86_compile_tac_if_cmp_goto() {
-
-	case_eq_true_8bit();
-	case_eq_false_8bit();
-
-	case_neq_true_8bit();
-	case_neq_false_8bit();
-
-	case_lt_true_8bit();
-	case_lt_false_8bit();
-
-	case_ge_true_8bit();
-	case_ge_false_8bit();
-}
 
 static void common(int a1, enum TAC_OP op, int a2, bool expect_true, bool debug) {
 
@@ -95,56 +71,56 @@ static void common(int a1, enum TAC_OP op, int a2, bool expect_true, bool debug)
 	sd_uc_close(system);
 }
 
-static void case_eq_true_8bit() {
+void test_x86_compile_tac_if_cmp_goto_case_eq_true_8bit() {
 
 	status_test_x86_codegen("TAC_IF_CMP_GOTO == true (8 bit)");
 
 	common(1, TAC_OP_CMP_EQ, 1, true, false);
 }
 
-static void case_eq_false_8bit() {
+void test_x86_compile_tac_if_cmp_goto_case_eq_false_8bit() {
 
 	status_test_x86_codegen("TAC_IF_CMP_GOTO == false (8 bit)");
 
 	common(1, TAC_OP_CMP_EQ, 2, false, false);
 }
 
-static void case_neq_true_8bit() {
+void test_x86_compile_tac_if_cmp_goto_case_neq_true_8bit() {
 
 	status_test_x86_codegen("TAC_IF_CMP_GOTO != true (8 bit)");
 
 	common(1, TAC_OP_CMP_NEQ, 2, true, false);
 }
 
-static void case_neq_false_8bit() {
+void test_x86_compile_tac_if_cmp_goto_case_neq_false_8bit() {
 
 	status_test_x86_codegen("TAC_IF_CMP_GOTO != false (8 bit)");
 
 	common(1, TAC_OP_CMP_NEQ, 1, false, false);
 }
 
-static void case_lt_true_8bit() {
+void test_x86_compile_tac_if_cmp_goto_case_lt_true_8bit() {
 
 	status_test_x86_codegen("TAC_IF_CMP_GOTO < true (8 bit)");
 
 	common(1, TAC_OP_CMP_LT, 4, true, false);
 }
 
-static void case_lt_false_8bit() {
+void test_x86_compile_tac_if_cmp_goto_case_lt_false_8bit() {
 
 	status_test_x86_codegen("TAC_IF_CMP_GOTO < false (8 bit)");
 
 	common(5, TAC_OP_CMP_LT, 4, false, false);
 }
 
-static void case_ge_true_8bit() {
+void test_x86_compile_tac_if_cmp_goto_case_ge_true_8bit() {
 
 	status_test_x86_codegen("TAC_IF_CMP_GOTO >= true (8 bit)");
 
 	common(4, TAC_OP_CMP_GE, 4, true, false);
 }
 
-static void case_ge_false_8bit() {
+void test_x86_compile_tac_if_cmp_goto_case_ge_false_8bit() {
 
 	status_test_x86_codegen("TAC_IF_CMP_GOTO >= false (8 bit)");
 

--- a/compiler/test/x86_code_gen/compile_ir/test_compile_tac_if_goto.c
+++ b/compiler/test/x86_code_gen/compile_ir/test_compile_tac_if_goto.c
@@ -12,18 +12,7 @@
 
 #include "test_compile_tac.h"
 
-static void case_true();
-static void case_false();
-static void case_mixed();
-
-void test_x86_compile_tac_if_goto() {
-
-	case_true();
-	case_false();
-	case_mixed();
-}
-
-static void case_true() {
+void test_x86_compile_tac_if_goto_case_true() {
 
 	status_test_x86_codegen("TAC_IF_GOTO true");
 
@@ -59,7 +48,7 @@ static void case_true() {
 	sd_uc_close(system);
 }
 
-static void case_false() {
+void test_x86_compile_tac_if_goto_case_false() {
 
 	status_test_x86_codegen("TAC_IF_GOTO false");
 
@@ -94,7 +83,7 @@ static void case_false() {
 	sd_uc_close(system);
 }
 
-static void case_mixed() {
+void test_x86_compile_tac_if_goto_case_mixed() {
 
 	status_test_x86_codegen("TAC_IF_GOTO mixed");
 

--- a/compiler/test/x86_code_gen/compile_ir/test_compile_tac_store.c
+++ b/compiler/test/x86_code_gen/compile_ir/test_compile_tac_store.c
@@ -20,16 +20,10 @@ void test_x86_compile_tac_store() {
 
 	const uint64_t start = sd_uc_default_start_addr() + 0x80;
 
-	common(start, 1000, false);
 	common(start + 1, 1000, false);
 
-	common(start, 1001, false);
 	common(start + 2, 1001, false);
 
-	common(start, 1002, false);
-	common(start + 5, 1002, false);
-
-	common(start, 1003, false);
 	common(start + 9, 1003, false);
 }
 

--- a/compiler/test/x86_code_gen/compile_ir/test_compile_tac_unary_op.c
+++ b/compiler/test/x86_code_gen/compile_ir/test_compile_tac_unary_op.c
@@ -12,22 +12,12 @@
 
 #include "test_compile_tac.h"
 
-static void case_minus(bool debug);
-static void case_not(bool debug);
-static void case_bitwise_neg(bool debug);
-
-void test_x86_compile_tac_unary_op() {
-
-	case_minus(false);
-	case_not(false);
-	case_bitwise_neg(false);
-}
-
-static void case_minus(bool debug) {
+void test_x86_compile_tac_unary_op_case_minus() {
+	bool debug = false;
 
 	status_test_x86_codegen("TAC_UNARY_OP -");
 
-	for (int8_t start = -40; start < 40; start += 10) {
+	for (int8_t start = -2; start < 2; start++) {
 
 		struct TACBuffer* b = tacbuffer_ctor();
 
@@ -48,7 +38,8 @@ static void case_minus(bool debug) {
 	}
 }
 
-static void case_not(bool debug) {
+void test_x86_compile_tac_unary_op_case_not() {
+	bool debug = false;
 
 	status_test_x86_codegen("TAC_UNARY_OP !");
 
@@ -76,13 +67,12 @@ static void case_not(bool debug) {
 	sd_uc_close(system);
 }
 
-static void case_bitwise_neg(bool debug) {
+void test_x86_compile_tac_unary_op_case_bitwise_neg() {
+	bool debug = false;
 
 	status_test_x86_codegen("TAC_UNARY_OP ~");
 
-	for (uint64_t start = 0; start < 10; start++) {
-		const uint64_t expect = ~start;
-
+	for (uint64_t start = 0; start < 3; start++) {
 		struct TACBuffer* b = tacbuffer_ctor();
 
 		tacbuffer_append(b, makeTACConst(0, start));
@@ -100,7 +90,7 @@ static void case_bitwise_neg(bool debug) {
 			printf("rax = 0x%lx (%ld)\n", rax, rax);
 		}
 
-		assert(rax == expect);
+		assert(rax == (~start));
 
 		sd_uc_close(system);
 	}


### PR DESCRIPTION
when running locally, the duration is now approximately 4635 instead of 17694.

Also made more of the tests to be individual tests listed in the toplevel function pointer array.

This helps as their duration can be measured individually.

resolves #86