### PR TITLE
compiler: avr: do not branch with limited range

### DIFF
--- a/compiler/main/avr_code_gen/compile_ir/compile_tac_goto.c
+++ b/compiler/main/avr_code_gen/compile_ir/compile_tac_goto.c
@@ -8,5 +8,8 @@ void compile_tac_goto(struct TAC* tac, struct IBuffer* ibu) {
 	char str[32];
 	sprintf(str, "L%d", tac->label_index);
 
-	rjmp(str, "TAC_GOTO");
+	jmp(str);
+
+	// cannot use rjmp, as it has only a limited range (+/- 2K words)
+	// TODO: check if 'jmp' instruction is available on the target mcu.
 }

--- a/compiler/main/avr_code_gen/compile_ir/compile_tac_if_cmp_goto.c
+++ b/compiler/main/avr_code_gen/compile_ir/compile_tac_if_cmp_goto.c
@@ -23,11 +23,21 @@ void compile_tac_if_cmp_goto(struct RAT* rat, struct TAC* tac, struct IBuffer* i
 	char str[32];
 	sprintf(str, "L%d", tac->label_index);
 
+	char tmp_label[32];
+	sprintf(tmp_label, "L%d", make_label());
+
+	// we invert the condition here so that we use 'jmp' for the jump to our target label.
+	// We cannot use 'brne', 'brlt', 'breq', ... as they can only jump +/- 64 words
+	// and we do not know how far away our target label is.
+
 	switch (tac->op) {
-		case TAC_OP_CMP_EQ: breq(str, c); break;
-		case TAC_OP_CMP_NEQ: brne(str, c); break;
-		case TAC_OP_CMP_GE: brge(str, c); break;
-		case TAC_OP_CMP_LT: brlt(str, c); break;
+		case TAC_OP_CMP_EQ: brne(tmp_label, c); break;
+		case TAC_OP_CMP_NEQ: breq(tmp_label, c); break;
+		case TAC_OP_CMP_GE: brlt(tmp_label, c); break;
+		case TAC_OP_CMP_LT: brge(tmp_label, c); break;
 		default: break;
 	}
+
+	jmp(str);
+	label(tmp_label);
 }

--- a/compiler/main/avr_code_gen/compile_ir/compile_tac_if_goto.c
+++ b/compiler/main/avr_code_gen/compile_ir/compile_tac_if_goto.c
@@ -13,8 +13,18 @@ void compile_tac_if_goto(struct RAT* rat, struct TAC* tac, struct IBuffer* ibu) 
 	char str[32];
 	sprintf(str, "L%d", tac->label_index);
 
+	char tmp_label[32];
+	sprintf(tmp_label, "L%d", make_label());
+
 	tst(reg, c); //test if r%d is zero
-	brne(str, c);
+
+	breq(tmp_label, c);
+	jmp(str);
+	label(tmp_label);
+
+	// brne(str, c);
+	// we cannot use brne since it can only branch +/- 64 words
+	// from the instruction pointer
 
 	// since a bool is only ever 1 byte
 	// there is no case for wide argument

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac_if_goto.c
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac_if_goto.c
@@ -23,8 +23,8 @@ void test_compile_tac_if_goto_case_true_8bit() {
 	const uint16_t address1 = 0x105;
 
 	//labels
-	const uint16_t l1 = 1;
-	const uint16_t lend = 2;
+	const uint16_t l1 = make_label();
+	const uint16_t lend = make_label();
 
 	struct TACBuffer* b = tacbuffer_ctor();
 
@@ -57,8 +57,8 @@ void test_compile_tac_if_goto_case_true_16bit() {
 	const uint16_t address1 = 0x101;
 
 	//labels
-	const uint16_t l1 = 1;
-	const uint16_t lend = 2;
+	const uint16_t l1 = make_label();
+	const uint16_t lend = make_label();
 
 	struct TACBuffer* b = tacbuffer_ctor();
 
@@ -91,8 +91,8 @@ void test_compile_tac_if_goto_case_false_8bit() {
 	const uint16_t address1 = 0x108;
 
 	//labels
-	const uint16_t l1 = 1;
-	const uint16_t lend = 2;
+	const uint16_t l1 = make_label();
+	const uint16_t lend = make_label();
 
 	struct TACBuffer* b = tacbuffer_ctor();
 
@@ -124,8 +124,8 @@ void test_compile_tac_if_goto_case_false_16bit() {
 	const uint16_t address1 = 0x109;
 
 	//labels
-	const uint16_t l1 = 1;
-	const uint16_t lend = 2;
+	const uint16_t l1 = make_label();
+	const uint16_t lend = make_label();
 
 	struct TACBuffer* b = tacbuffer_ctor();
 
@@ -163,8 +163,8 @@ void test_compile_tac_if_goto_case_mixed() {
 	const uint16_t address2 = address1 + 1;
 
 	//labels
-	const uint16_t l1 = 1;
-	const uint16_t lend = 2;
+	const uint16_t l1 = make_label();
+	const uint16_t lend = make_label();
 
 	struct TACBuffer* b = tacbuffer_ctor();
 


### PR DESCRIPTION
Before, the code was branching using 'brne','brlt' and such directly to the target label.

But the distance of that label is unknown at that time. And brne,brle,breq,... all can only branch +/- 64 words from the instruction pointer.

So they cannot be used and 'jmp' must be used. We can skip the 'jmp' if needed by using 'brne','brlt','breq'..., inverting the original condition.