### PR TITLE
lexer: optimize tokens

### DIFF
--- a/compiler/main/gen_tac/gen_tac_expr.c
+++ b/compiler/main/gen_tac/gen_tac_expr.c
@@ -94,9 +94,9 @@ static enum TAC_OP op_to_tac_op(enum OP o, bool* reverse_operands) {
 
 		case OP_NONE:
 		default:
-			printf("error in op_to_tac_op\n");
-			printf("error, op was none of supported TAC_OP_... values\n");
-			printf("op = %d\n", o);
+			fprintf(stderr, "error in op_to_tac_op\n");
+			fprintf(stderr, "error, op was none of supported TAC_OP_... values\n");
+			fprintf(stderr, "op = %d\n", o);
 			break;
 	}
 

--- a/lexer/src/driver.c
+++ b/lexer/src/driver.c
@@ -11,6 +11,10 @@
 
 #include "../../token/TokenKeys.h"
 
+void out_nostr(FILE* outFile, int id) {
+	fprintf(outFile, "%d\n", id);
+}
+
 void out(FILE* outFile, int id, char* str) {
 	char* s = str;
 	if (str == NULL) {
@@ -31,12 +35,12 @@ void out2(FILE* outFile, int id, int id2) {
 }
 
 void out_plus_plus(FILE* outFile) {
-	out(outFile, ASSIGNOP, "+=");
+	out(outFile, ASSIGNOP_PLUS, "+=");
 	out(outFile, INTEGER, "1");
 }
 
 void out_minus_minus(FILE* outFile) {
-	out(outFile, ASSIGNOP, "-=");
+	out(outFile, ASSIGNOP_MINUS, "-=");
 	out(outFile, INTEGER, "1");
 }
 

--- a/lexer/src/driver.h
+++ b/lexer/src/driver.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 
+void out_nostr(FILE* outFile, int id);
 void out(FILE* outFile, int id, char* str);
 void out_length(FILE* outFile, int id, char* str, int length);
 

--- a/lexer/test/testcases/tests_mixed.c
+++ b/lexer/test/testcases/tests_mixed.c
@@ -17,7 +17,6 @@ void test_mixed_1() {
 	assert(tokens[2]->kind == LCURLY);
 
 	assert(tokens[3]->kind == TYPEID_PRIMITIVE_UINT);
-	assert(strcmp(tokens[3]->value_ptr, "uint") == 0);
 
 	assert(tokens[4]->kind == ID);
 	assert(strcmp(tokens[4]->value_ptr, "a") == 0);
@@ -41,7 +40,7 @@ void test_mixed_2() {
 
 	assert(tokens[2]->kind == RPARENS);
 
-	assert(tokens[3]->kind == ARROW);
+	assert(tokens[3]->kind == ARROW_SIDE_EFFECT);
 
 	free_tokens(tokens, 4);
 }
@@ -84,7 +83,7 @@ void test_mixed_5() {
 	struct Token** tokens = lex(str);
 
 	assert(tokens[0]->kind == RBRACKET);
-	assert(tokens[1]->kind == ASSIGNOP);
+	assert(tokens[1]->kind == ASSIGNOP_SIMPLE);
 	assert(tokens[2]->kind == CCONST);
 	assert(tokens[3]->kind == SEMICOLON);
 
@@ -114,7 +113,7 @@ void test_mixed_7() {
 
 	assert(tokens[0]->kind == LPARENS);
 	assert(tokens[1]->kind == INTEGER);
-	assert(tokens[2]->kind == OPKEY_RELATIONAL);
+	assert(tokens[2]->kind == OPKEY_RELATIONAL_LT);
 	assert(tokens[3]->kind == INTEGER);
 	assert(tokens[4]->kind == RPARENS);
 
@@ -163,7 +162,7 @@ void test_mixed_10() {
 	assert(tokens[1]->kind == ID);
 	assert(tokens[1]->line_num == 2);
 
-	assert(tokens[2]->kind == ASSIGNOP);
+	assert(tokens[2]->kind == ASSIGNOP_SIMPLE);
 	assert(tokens[3]->kind == INTEGER);
 
 	free_tokens(tokens, 5);
@@ -194,7 +193,7 @@ void test_mixed_12() {
 
 	assert(tokens[0]->kind == LPARENS);
 	assert(tokens[1]->kind == ID);
-	assert(tokens[2]->kind == OPKEY_RELATIONAL);
+	assert(tokens[2]->kind == OPKEY_RELATIONAL_LT);
 	assert(tokens[3]->kind == INTEGER);
 	assert(tokens[4]->kind == RPARENS);
 
@@ -284,7 +283,7 @@ void test_mixed_16() {
 	assert(tokens[2]->kind == TYPEID_PRIMITIVE_UINT);
 
 	assert(tokens[3]->kind == RPARENS);
-	assert(tokens[4]->kind == ARROW);
+	assert(tokens[4]->kind == ARROW_NO_SIDE_EFFECT);
 	assert(tokens[5]->kind == TYPEID_PRIMITIVE_BOOL);
 	assert(tokens[6]->kind == RPARENS);
 	assert(tokens[7]->kind == ID);

--- a/lexer/test/testcases/tests_operators.c
+++ b/lexer/test/testcases/tests_operators.c
@@ -11,22 +11,18 @@ void test_operators() {
 
 	printt("test operators\n");
 
-	char* str = "+ - * ";
+	char* str = "+ - * / ";
 	struct Token** tokens = lex(str);
 
 	assert(tokens != NULL);
 	assert(tokens[0] != NULL);
 
-	assert(tokens[0]->kind == OPKEY_ARITHMETIC);
-	assert(strcmp(tokens[0]->value_ptr, "+") == 0);
+	assert(tokens[0]->kind == OPKEY_ARITHMETIC_PLUS);
+	assert(tokens[1]->kind == OPKEY_ARITHMETIC_MINUS);
+	assert(tokens[2]->kind == OPKEY_ARITHMETIC_MUL);
+	assert(tokens[3]->kind == OPKEY_ARITHMETIC_DIV);
 
-	assert(tokens[1]->kind == OPKEY_ARITHMETIC);
-	assert(strcmp(tokens[1]->value_ptr, "-") == 0);
-
-	assert(tokens[2]->kind == OPKEY_ARITHMETIC);
-	assert(strcmp(tokens[2]->value_ptr, "*") == 0);
-
-	free_tokens(tokens, 3);
+	free_tokens(tokens, 4);
 }
 
 void test_operators_cmp() {
@@ -39,23 +35,12 @@ void test_operators_cmp() {
 	assert(tokens != NULL);
 	assert(tokens[0] != NULL);
 
-	assert(tokens[0]->kind == OPKEY_RELATIONAL);
-	assert(strcmp(tokens[0]->value_ptr, "<=") == 0);
-
-	assert(tokens[1]->kind == OPKEY_RELATIONAL);
-	assert(strcmp(tokens[1]->value_ptr, ">=") == 0);
-
-	assert(tokens[2]->kind == OPKEY_RELATIONAL);
-	assert(strcmp(tokens[2]->value_ptr, "==") == 0);
-
-	assert(tokens[3]->kind == OPKEY_RELATIONAL);
-	assert(strcmp(tokens[3]->value_ptr, "!=") == 0);
-
-	assert(tokens[4]->kind == OPKEY_RELATIONAL);
-	assert(strcmp(tokens[4]->value_ptr, "<") == 0);
-
-	assert(tokens[5]->kind == OPKEY_RELATIONAL);
-	assert(strcmp(tokens[5]->value_ptr, ">") == 0);
+	assert(tokens[0]->kind == OPKEY_RELATIONAL_LE);
+	assert(tokens[1]->kind == OPKEY_RELATIONAL_GE);
+	assert(tokens[2]->kind == OPKEY_RELATIONAL_EQ);
+	assert(tokens[3]->kind == OPKEY_RELATIONAL_NEQ);
+	assert(tokens[4]->kind == OPKEY_RELATIONAL_LT);
+	assert(tokens[5]->kind == OPKEY_RELATIONAL_GT);
 
 	free_tokens(tokens, 6);
 }
@@ -70,11 +55,9 @@ void test_operators_logical() {
 	assert(tokens != NULL);
 	assert(tokens[0] != NULL);
 
-	assert(tokens[0]->kind == OPKEY_LOGICAL);
-	assert(strcmp(tokens[0]->value_ptr, "&&") == 0);
+	assert(tokens[0]->kind == OPKEY_LOGICAL_AND);
 
-	assert(tokens[1]->kind == OPKEY_LOGICAL);
-	assert(strcmp(tokens[1]->value_ptr, "||") == 0);
+	assert(tokens[1]->kind == OPKEY_LOGICAL_OR);
 
 	free_tokens(tokens, 2);
 }
@@ -89,23 +72,12 @@ void test_operators_bitwise() {
 	assert(tokens != NULL);
 	assert(tokens[0] != NULL);
 
-	assert(tokens[0]->kind == OPKEY_BITWISE);
-	assert(strcmp(tokens[0]->value_ptr, "|") == 0);
-
-	assert(tokens[1]->kind == OPKEY_BITWISE);
-	assert(strcmp(tokens[1]->value_ptr, "&") == 0);
-
-	assert(tokens[2]->kind == OPKEY_BITWISE);
-	assert(strcmp(tokens[2]->value_ptr, "<<") == 0);
-
-	assert(tokens[3]->kind == OPKEY_BITWISE);
-	assert(strcmp(tokens[3]->value_ptr, ">>") == 0);
-
-	assert(tokens[4]->kind == OPKEY_BITWISE);
-	assert(strcmp(tokens[4]->value_ptr, "^") == 0);
-
-	assert(tokens[5]->kind == OPKEY_BITWISE);
-	assert(strcmp(tokens[5]->value_ptr, "~") == 0);
+	assert(tokens[0]->kind == OPKEY_BITWISE_OR);
+	assert(tokens[1]->kind == OPKEY_BITWISE_AND);
+	assert(tokens[2]->kind == OPKEY_BITWISE_SHIFT_LEFT);
+	assert(tokens[3]->kind == OPKEY_BITWISE_SHIFT_RIGHT);
+	assert(tokens[4]->kind == OPKEY_BITWISE_XOR);
+	assert(tokens[5]->kind == OPKEY_BITWISE_NOT);
 
 	free_tokens(tokens, 6);
 }
@@ -121,28 +93,17 @@ void test_assign_operators() {
 	assert(tokens[0] != NULL);
 
 	// =
-	assert(tokens[0]->kind == ASSIGNOP);
-	assert(strcmp(tokens[0]->value_ptr, "=") == 0);
+	assert(tokens[0]->kind == ASSIGNOP_SIMPLE);
 
 	// arithmetic
-	assert(tokens[1]->kind == ASSIGNOP);
-	assert(strcmp(tokens[1]->value_ptr, "+=") == 0);
-
-	assert(tokens[2]->kind == ASSIGNOP);
-	assert(strcmp(tokens[2]->value_ptr, "-=") == 0);
+	assert(tokens[1]->kind == ASSIGNOP_PLUS);
+	assert(tokens[2]->kind == ASSIGNOP_MINUS);
 
 	// bitwise
-	assert(tokens[3]->kind == ASSIGNOP);
-	assert(strcmp(tokens[3]->value_ptr, ">>=") == 0);
-
-	assert(tokens[4]->kind == ASSIGNOP);
-	assert(strcmp(tokens[4]->value_ptr, "<<=") == 0);
-
-	assert(tokens[5]->kind == ASSIGNOP);
-	assert(strcmp(tokens[5]->value_ptr, "&=") == 0);
-
-	assert(tokens[6]->kind == ASSIGNOP);
-	assert(strcmp(tokens[6]->value_ptr, "|=") == 0);
+	assert(tokens[3]->kind == ASSIGNOP_SHIFT_RIGHT);
+	assert(tokens[4]->kind == ASSIGNOP_SHIFT_LEFT);
+	assert(tokens[5]->kind == ASSIGNOP_BITWISE_AND);
+	assert(tokens[6]->kind == ASSIGNOP_BITWISE_OR);
 
 	free_tokens(tokens, 7);
 }

--- a/lexer/test/testcases/tests_other.c
+++ b/lexer/test/testcases/tests_other.c
@@ -9,6 +9,8 @@
 
 void test_plus_plus_minus_minus() {
 
+	printt("test ++, --\n");
+
 	char* str = "Char ++ -- ";
 	//should expand: "Char += 1 -= 1"
 	struct Token** tokens = lex(str);
@@ -17,14 +19,12 @@ void test_plus_plus_minus_minus() {
 	assert(tokens[0] != NULL);
 
 	assert(tokens[0]->kind == TYPEID);
-	assert(tokens[1]->kind == ASSIGNOP);
+	assert(tokens[1]->kind == ASSIGNOP_PLUS);
 	assert(tokens[2]->kind == INTEGER);
-	assert(tokens[3]->kind == ASSIGNOP);
+	assert(tokens[3]->kind == ASSIGNOP_MINUS);
 	assert(tokens[4]->kind == INTEGER);
 
-	assert(strcmp(tokens[1]->value_ptr, "+=") == 0);
 	assert(strcmp(tokens[2]->value_ptr, "1") == 0);
-	assert(strcmp(tokens[3]->value_ptr, "-=") == 0);
 	assert(strcmp(tokens[4]->value_ptr, "1") == 0);
 
 	free_tokens(tokens, 5);
@@ -60,9 +60,9 @@ void test_can_see_line_with_operators() {
 	assert(tokens[0] != NULL);
 
 	assert(tokens[0]->kind == ID);
-	assert(tokens[1]->kind == ASSIGNOP);
+	assert(tokens[1]->kind == ASSIGNOP_SIMPLE);
 	assert(tokens[2]->kind == ID);
-	assert(tokens[3]->kind == OPKEY_ARITHMETIC);
+	assert(tokens[3]->kind == OPKEY_ARITHMETIC_PLUS);
 	assert(tokens[4]->kind == ID);
 
 	free_tokens(tokens, 6);
@@ -81,11 +81,11 @@ void test_lexes_return_statement_favorably() {
 	assert(tokens[0]->kind == RETURN);
 
 	assert(tokens[1]->kind == LPARENS);
-	assert(tokens[2]->kind == OPKEY_ARITHMETIC);
+	assert(tokens[2]->kind == OPKEY_ARITHMETIC_MINUS);
 	assert(tokens[3]->kind == INTEGER);
 	assert(tokens[4]->kind == RPARENS);
 
-	assert(tokens[5]->kind == OPKEY_ARITHMETIC);
+	assert(tokens[5]->kind == OPKEY_ARITHMETIC_MUL);
 	assert(tokens[6]->kind == ID);
 	assert(tokens[7]->kind == SEMICOLON);
 
@@ -103,12 +103,12 @@ void test_lexes_other_return_statement() {
 
 	assert(tokens[1]->kind == LPARENS);
 	assert(tokens[2]->kind == ID);
-	assert(tokens[3]->kind == OPKEY_ARITHMETIC);
+	assert(tokens[3]->kind == OPKEY_ARITHMETIC_MUL);
 	assert(tokens[4]->kind == ID);
 
 	assert(tokens[5]->kind == LPARENS);
 	assert(tokens[6]->kind == ID);
-	assert(tokens[7]->kind == OPKEY_ARITHMETIC);
+	assert(tokens[7]->kind == OPKEY_ARITHMETIC_MINUS);
 	assert(tokens[8]->kind == INTEGER);
 	assert(tokens[9]->kind == RPARENS);
 	assert(tokens[10]->kind == RPARENS);
@@ -210,12 +210,10 @@ void test_typeidentifier_primitive() {
 	    TYPEID_PRIMITIVE_UINT16,
 	};
 
-	char* expect[] = {"int", "uint", "int8", "uint8", "int16", "uint16"};
 	size_t expect_count = 6;
 
 	for (int i = 0; i < expect_count; i++) {
 		assert(tokens[i]->kind == expect_kind[i]);
-		assert(strcmp(tokens[i]->value_ptr, expect[i]) == 0);
 	}
 
 	free_tokens(tokens, expect_count);
@@ -266,11 +264,8 @@ void test_arrow() {
 	char* str = "-> ~> ";
 	struct Token** tokens = lex(str);
 
-	assert(tokens[0]->kind == ARROW);
-	assert(strcmp(tokens[0]->value_ptr, "->") == 0);
-
-	assert(tokens[1]->kind == ARROW);
-	assert(strcmp(tokens[1]->value_ptr, "~>") == 0);
+	assert(tokens[0]->kind == ARROW_NO_SIDE_EFFECT);
+	assert(tokens[1]->kind == ARROW_SIDE_EFFECT);
 
 	free_tokens(tokens, 2);
 }
@@ -319,7 +314,7 @@ void test_member_access() {
 	assert(tokens[1]->kind == STRUCTMEMBERACCESS);
 	assert(tokens[2]->kind == ID);
 
-	assert(tokens[3]->kind == ASSIGNOP);
+	assert(tokens[3]->kind == ASSIGNOP_SIMPLE);
 
 	free_tokens(tokens, 4);
 }
@@ -337,11 +332,8 @@ void test_brackets() {
 	assert(tokens[3]->kind == RPARENS);
 	assert(tokens[4]->kind == LCURLY);
 	assert(tokens[5]->kind == RCURLY);
-	assert(tokens[6]->kind == OPKEY_RELATIONAL);
-	assert(tokens[7]->kind == OPKEY_RELATIONAL);
-
-	assert(strcmp(tokens[6]->value_ptr, "<") == 0);
-	assert(strcmp(tokens[7]->value_ptr, ">") == 0);
+	assert(tokens[6]->kind == OPKEY_RELATIONAL_LT);
+	assert(tokens[7]->kind == OPKEY_RELATIONAL_GT);
 
 	free_tokens(tokens, 8);
 }

--- a/parser/main/astnodes/const/IntConst.c
+++ b/parser/main/astnodes/const/IntConst.c
@@ -26,11 +26,8 @@ int32_t makeIntConst(struct TokenList* tokens, bool* error) {
 
 	switch (tk->kind) {
 
-		case OPKEY_ARITHMETIC:;
-			if (
-			    strcmp(tk->value_ptr, "-") == 0 && (list_get(copy, 1)->kind == INTEGER)
-
-			) {
+		case OPKEY_ARITHMETIC_MINUS:;
+			if (list_get(copy, 1)->kind == INTEGER) {
 				struct Token* mytk = list_get(copy, 1);
 				if (mytk == NULL) {
 					freeTokenListShallow(copy);

--- a/parser/main/astnodes/expr/Op.c
+++ b/parser/main/astnodes/expr/Op.c
@@ -3,11 +3,10 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include "ast/ast/ast_expr.h"
 #include "parser/main/util/parse_astnode.h"
 
 #include "Op.h"
-
-#include "ast/util/free_ast.h"
 
 #include "token/list/TokenList.h"
 #include "token/TokenKeys.h"
@@ -20,40 +19,89 @@ enum OP makeOp(struct TokenList* tokens) {
 	struct Token* tk = list_head(copy);
 	if (tk == NULL) { return OP_NONE; }
 
-	switch (tk->kind) {
+	enum OP res = OP_NONE;
 
-		case OPKEY_ARITHMETIC:
-		case OPKEY_RELATIONAL:
-		case OPKEY_LOGICAL:
-		case OPKEY_BITWISE: break;
+	switch (tk->kind) {
+		case ASSIGNOP_PLUS:
+			res = OP_PLUS;
+			break;
+		case ASSIGNOP_MINUS:
+			res = OP_MINUS;
+			break;
+		case ASSIGNOP_SHIFT_LEFT:
+			res = OP_SHIFT_LEFT;
+			break;
+		case ASSIGNOP_SHIFT_RIGHT:
+			res = OP_SHIFT_RIGHT;
+			break;
+		case ASSIGNOP_BITWISE_AND:
+			res = OP_AND;
+			break;
+		case ASSIGNOP_BITWISE_OR:
+			res = OP_OR;
+			break;
+
+		case OPKEY_ARITHMETIC_PLUS:
+			res = OP_PLUS;
+			break;
+		case OPKEY_ARITHMETIC_MINUS:
+			res = OP_MINUS;
+			break;
+		case OPKEY_ARITHMETIC_MUL:
+			res = OP_MULTIPLY;
+			break;
+		case OPKEY_ARITHMETIC_DIV:
+			break;
+		case OPKEY_RELATIONAL_EQ:
+			res = OP_EQ;
+			break;
+		case OPKEY_RELATIONAL_NEQ:
+			res = OP_NEQ;
+			break;
+		case OPKEY_RELATIONAL_LT:
+			res = OP_LT;
+			break;
+		case OPKEY_RELATIONAL_GT:
+			res = OP_GT;
+			break;
+		case OPKEY_RELATIONAL_LE:
+			res = OP_LE;
+			break;
+		case OPKEY_RELATIONAL_GE:
+			res = OP_GE;
+			break;
+		case OPKEY_LOGICAL_AND:
+			res = OP_AND;
+			break;
+		case OPKEY_LOGICAL_OR:
+			res = OP_OR;
+			break;
+		case OPKEY_LOGICAL_NOT:
+			res = OP_NOT;
+			break;
+		case OPKEY_BITWISE_OR:
+			res = OP_OR;
+			break;
+		case OPKEY_BITWISE_AND:
+			res = OP_AND;
+			break;
+		case OPKEY_BITWISE_XOR:
+			res = OP_XOR;
+			break;
+		case OPKEY_BITWISE_NOT:
+			res = OP_NOT;
+			break;
+		case OPKEY_BITWISE_SHIFT_LEFT:
+			res = OP_SHIFT_LEFT;
+			break;
+		case OPKEY_BITWISE_SHIFT_RIGHT:
+			res = OP_SHIFT_RIGHT;
+			break;
 
 		default:
 			freeTokenListShallow(copy);
 			return OP_NONE;
 	}
-
-	enum OP res = OP_NONE;
-
-	if (strcmp(tk->value_ptr, "+") == 0) res = OP_PLUS;
-	if (strcmp(tk->value_ptr, "-") == 0) res = OP_MINUS;
-	if (strcmp(tk->value_ptr, "*") == 0) res = OP_MULTIPLY;
-
-	if (strcmp(tk->value_ptr, "<<") == 0) res = OP_SHIFT_LEFT;
-	if (strcmp(tk->value_ptr, ">>") == 0) res = OP_SHIFT_RIGHT;
-
-	if (strcmp(tk->value_ptr, "==") == 0) res = OP_EQ;
-	if (strcmp(tk->value_ptr, "!=") == 0) res = OP_NEQ;
-	if (strcmp(tk->value_ptr, ">=") == 0) res = OP_GE;
-	if (strcmp(tk->value_ptr, "<=") == 0) res = OP_LE;
-	if (strcmp(tk->value_ptr, ">") == 0) res = OP_GT;
-	if (strcmp(tk->value_ptr, "<") == 0) res = OP_LT;
-
-	if (strcmp(tk->value_ptr, "&") == 0) res = OP_AND;
-	if (strcmp(tk->value_ptr, "|") == 0) res = OP_OR;
-	if (strcmp(tk->value_ptr, "^") == 0) res = OP_XOR;
-
-	if (strcmp(tk->value_ptr, "!") == 0) res = OP_NOT;
-	if (strcmp(tk->value_ptr, "~") == 0) res = OP_COMPLEMENT;
 
 	list_consume(copy, 1);
 

--- a/parser/main/astnodes/statements/MAssignStmt.c
+++ b/parser/main/astnodes/statements/MAssignStmt.c
@@ -24,15 +24,23 @@ struct MAssignStmt* makeMAssignStmt(struct TokenList* tokens) {
 	//parse '='
 	struct Token* head = list_head(copy);
 
-	if (head->kind != ASSIGNOP) {
+	if (
+	    head->kind != ASSIGNOP_PLUS &&
+	    head->kind != ASSIGNOP_MINUS &&
+	    head->kind != ASSIGNOP_SHIFT_LEFT &&
+	    head->kind != ASSIGNOP_SHIFT_RIGHT &&
+	    head->kind != ASSIGNOP_BITWISE_AND &&
+	    head->kind != ASSIGNOP_BITWISE_OR &&
+	    head->kind != ASSIGNOP_SIMPLE) {
 		free(res);
 		freeTokenListShallow(copy);
 		return NULL;
 	}
 
-	if (strcmp(head->value_ptr, "=") != 0) {
-		printf("expected assign op to be '=' for MAssignStmt. Exiting\n");
-		exit(1);
+	if (head->kind != ASSIGNOP_SIMPLE) {
+		fprintf(stderr, "expected assign op to be '=' for MAssignStmt. Exiting\n");
+		free(res);
+		freeTokenListShallow(copy);
 		return NULL;
 	}
 

--- a/parser/main/astnodes/subr/MethodDecl.c
+++ b/parser/main/astnodes/subr/MethodDecl.c
@@ -50,19 +50,13 @@ struct MethodDecl* makeMethodDecl(struct TokenList* tokens) {
 
 	{
 		struct Token* tk = list_head(copy);
-		if (tk->kind != ARROW) {
+		if (tk->kind != ARROW_NO_SIDE_EFFECT && tk->kind != ARROW_SIDE_EFFECT) {
 			free(res);
 			freeTokenListShallow(copy);
 			return NULL;
 		}
-		if (strcmp(tk->value_ptr, "->") == 0) {
-			res->has_side_effects = false;
-		} else if (strcmp(tk->value_ptr, "~>") == 0) {
-			res->has_side_effects = true;
-		} else {
-			printf("Fatal\n");
-			exit(1);
-		}
+
+		res->has_side_effects = (tk->kind == ARROW_SIDE_EFFECT);
 
 		list_consume(copy, 1);
 	}

--- a/parser/main/astnodes/types/SubrType.c
+++ b/parser/main/astnodes/types/SubrType.c
@@ -81,20 +81,14 @@ struct SubrType* makeSubrType(struct TokenList* tokens) {
 
 	{
 		struct Token* tk = list_head(copy);
-		if (tk->kind != ARROW) {
+		if (tk->kind != ARROW_SIDE_EFFECT && tk->kind != ARROW_NO_SIDE_EFFECT) {
 			free(res->arg_types);
 			free(res);
 			freeTokenListShallow(copy);
 			return NULL;
 		}
-		if (strcmp(tk->value_ptr, "->") == 0) {
-			res->has_side_effects = false;
-		} else if (strcmp(tk->value_ptr, "~>") == 0) {
-			res->has_side_effects = true;
-		} else {
-			printf("Fatal\n");
-			exit(1);
-		}
+
+		res->has_side_effects = (tk->kind == ARROW_SIDE_EFFECT);
 
 		list_consume(copy, 1);
 	}

--- a/parser/test/astnodes/NamespaceTest.c
+++ b/parser/test/astnodes/NamespaceTest.c
@@ -43,7 +43,7 @@ int namespace_test_can_parse_namespace_with_1_empty_method() {
 	list_add(l, makeToken2(ID, "main"));
 	list_add(l, makeToken(LPARENS));
 	list_add(l, makeToken(RPARENS));
-	list_add(l, makeToken2(ARROW, "~>"));
+	list_add(l, makeToken(ARROW_SIDE_EFFECT));
 	list_add(l, makeToken2(TYPEID, "uint"));
 	list_add(l, makeToken(LCURLY));
 	list_add(l, makeToken(RCURLY));

--- a/parser/test/astnodes/StmtBlockTest.c
+++ b/parser/test/astnodes/StmtBlockTest.c
@@ -22,7 +22,7 @@ int test_stmtblock_1() {
 	list_add(tokens, makeToken2(LCURLY, "{"));
 
 	list_add(tokens, makeToken2(ID, "a"));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken2(ASSIGNOP_SIMPLE, "="));
 	list_add(tokens, makeToken2(INTEGER, "3"));
 	list_add(tokens, makeToken(SEMICOLON));
 

--- a/parser/test/astnodes/expr/ExprTest.c
+++ b/parser/test/astnodes/expr/ExprTest.c
@@ -61,7 +61,7 @@ int expr_recognize_2_op_expr() {
 	struct TokenList* tokens = makeTokenList();
 
 	list_add(tokens, makeToken2(INTEGER, "1"));
-	list_add(tokens, makeToken2(OPKEY_ARITHMETIC, "+"));
+	list_add(tokens, makeToken(OPKEY_ARITHMETIC_PLUS));
 	list_add(tokens, makeToken2(INTEGER, "2"));
 
 	list_add(tokens, makeToken2(LCURLY, "{"));
@@ -83,7 +83,7 @@ int expr_test_comparison() {
 	struct TokenList* l = makeTokenList();
 
 	list_add(l, makeToken2(ID, "x"));
-	list_add(l, makeToken2(OPKEY_RELATIONAL, "<"));
+	list_add(l, makeToken(OPKEY_RELATIONAL_LT));
 	list_add(l, makeToken2(INTEGER, "5"));
 
 	list_add(l, makeToken2(LCURLY, "{"));
@@ -128,9 +128,9 @@ int expr_test_3_terms() {
 	struct TokenList* tokens = makeTokenList();
 
 	list_add(tokens, makeToken2(INTEGER, "1"));
-	list_add(tokens, makeToken2(OPKEY_ARITHMETIC, "+"));
+	list_add(tokens, makeToken(OPKEY_ARITHMETIC_PLUS));
 	list_add(tokens, makeToken2(INTEGER, "2"));
-	list_add(tokens, makeToken2(OPKEY_ARITHMETIC, "+"));
+	list_add(tokens, makeToken(OPKEY_ARITHMETIC_PLUS));
 	list_add(tokens, makeToken2(INTEGER, "3"));
 
 	list_add(tokens, makeToken2(LCURLY, "{"));

--- a/parser/test/astnodes/expr/UnOpTermTest.c
+++ b/parser/test/astnodes/expr/UnOpTermTest.c
@@ -19,7 +19,7 @@ int test_unop_with() {
 	status_test("test_unop_with");
 
 	struct TokenList* list = makeTokenList();
-	list_add(list, makeToken2(OPKEY_LOGICAL, "!"));
+	list_add(list, makeToken(OPKEY_LOGICAL_NOT));
 	list_add(list, makeToken2(INTEGER, "4"));
 
 	struct UnOpTerm* t = makeUnOpTerm(list);

--- a/parser/test/astnodes/statements/AssignStmtTest.c
+++ b/parser/test/astnodes/statements/AssignStmtTest.c
@@ -21,7 +21,7 @@ int assignstmt_test1() {
 	struct TokenList* tokens = makeTokenList();
 
 	list_add(tokens, makeToken2(ID, "x"));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken(ASSIGNOP_SIMPLE));
 	list_add(tokens, makeToken2(INTEGER, "4"));
 	list_add(tokens, makeToken(SEMICOLON));
 
@@ -42,7 +42,7 @@ int assignstmt_test_assign_method_call_result() {
 	struct TokenList* tokens = makeTokenList();
 
 	list_add(tokens, makeToken2(ID, "x"));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken(ASSIGNOP_SIMPLE));
 
 	//nop refers to the no operation method. it does nothing with its argument
 	list_add(tokens, makeToken2(ID, "nop"));
@@ -70,7 +70,7 @@ int assignstmt_test_assign_method_call_result_2() {
 	struct TokenList* tokens = makeTokenList();
 
 	list_add(tokens, makeToken2(ID, "x"));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken(ASSIGNOP_SIMPLE));
 
 	//nop refers to the no operation method. it does nothing with its argument
 	list_add(tokens, makeToken2(ID, "nop"));
@@ -96,7 +96,7 @@ int assignstmt_test_assign_variable_with_array_index() {
 	struct TokenList* tokens = makeTokenList();
 
 	list_add(tokens, makeToken2(ID, "x"));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken(ASSIGNOP_SIMPLE));
 
 	//nop refers to the no operation method. it does nothing with its argument
 	list_add(tokens, makeToken2(ID, "arr"));
@@ -123,7 +123,7 @@ int assignstmt_test_assign_char() {
 	struct TokenList* tokens = makeTokenList();
 
 	list_add(tokens, makeToken2(ID, "x"));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken(ASSIGNOP_SIMPLE));
 
 	list_add(tokens, makeToken2(CCONST, "x"));
 
@@ -148,7 +148,7 @@ int assignstmt_test_can_assign_to_struct_member() {
 	list_add(tokens, makeToken2(ID, "x"));
 	list_add(tokens, makeToken(STRUCTMEMBERACCESS));
 	list_add(tokens, makeToken2(ID, "a"));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken(ASSIGNOP_SIMPLE));
 	list_add(tokens, makeToken2(INTEGER, "3"));
 	list_add(tokens, makeToken(SEMICOLON));
 
@@ -170,7 +170,7 @@ int assignstmt_test_type_declaration_for_variable() {
 
 	list_add(tokens, makeToken2(TYPEID, "Carrot"));
 	list_add(tokens, makeToken2(ID, "x"));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken(ASSIGNOP_SIMPLE));
 	list_add(tokens, makeToken2(INTEGER, "3"));
 	list_add(tokens, makeToken(SEMICOLON));
 

--- a/parser/test/astnodes/statements/IfStmtTest.c
+++ b/parser/test/astnodes/statements/IfStmtTest.c
@@ -22,12 +22,12 @@ int if_test1() {
 	list_add(list, makeToken2(IF, "if"));
 
 	list_add(list, makeToken2(INTEGER, "5"));
-	list_add(list, makeToken2(OPKEY_RELATIONAL, "<"));
+	list_add(list, makeToken(OPKEY_RELATIONAL_LT));
 	list_add(list, makeToken2(INTEGER, "3"));
 
-	list_add(list, makeToken2(LCURLY, "{"));
+	list_add(list, makeToken(LCURLY));
 
-	list_add(list, makeToken2(RCURLY, "}"));
+	list_add(list, makeToken(RCURLY));
 
 	struct IfStmt* i = makeIfStmt(list);
 
@@ -58,20 +58,20 @@ int if_test2() {
 	list_add(l, makeToken2(IF, "if"));
 
 	list_add(l, makeToken2(ID, "x"));
-	list_add(l, makeToken2(OPKEY_RELATIONAL, "<"));
+	list_add(l, makeToken(OPKEY_RELATIONAL_LT));
 	list_add(l, makeToken2(INTEGER, "5"));
 
-	list_add(l, makeToken2(LCURLY, "{"));
+	list_add(l, makeToken(LCURLY));
 
 	list_add(l, makeToken2(ID, "println"));
 
-	list_add(l, makeToken2(LPARENS, "("));
+	list_add(l, makeToken(LPARENS));
 	list_add(l, makeToken2(INTEGER, "5"));
-	list_add(l, makeToken2(RPARENS, ")"));
+	list_add(l, makeToken(RPARENS));
 
-	list_add(l, makeToken2(SEMICOLON, ";"));
+	list_add(l, makeToken(SEMICOLON));
 
-	list_add(l, makeToken2(RCURLY, "}"));
+	list_add(l, makeToken(RCURLY));
 
 	struct IfStmt* i = makeIfStmt(l);
 

--- a/parser/test/astnodes/statements/MAssignStmtTest.c
+++ b/parser/test/astnodes/statements/MAssignStmtTest.c
@@ -24,7 +24,7 @@ bool massignstmt_test1() {
 	list_add(tokens, makeToken(LBRACKET));
 	list_add(tokens, makeToken2(INTEGER, "4"));
 	list_add(tokens, makeToken(RBRACKET));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken(ASSIGNOP_SIMPLE));
 
 	list_add(tokens, makeToken2(INTEGER, "5"));
 

--- a/parser/test/astnodes/statements/RetStmtTest.c
+++ b/parser/test/astnodes/statements/RetStmtTest.c
@@ -23,7 +23,7 @@ int retstmt_test1() {
 
 	list_add(list, makeToken(LPARENS));
 
-	list_add(list, makeToken2(OPKEY_ARITHMETIC, "-"));
+	list_add(list, makeToken(OPKEY_ARITHMETIC_MINUS));
 	list_add(list, makeToken2(INTEGER, "5"));
 
 	list_add(list, makeToken(RPARENS));
@@ -48,13 +48,13 @@ int retstmt_test2() {
 
 	list_add(list, makeToken(LPARENS));
 
-	list_add(list, makeToken2(OPKEY_ARITHMETIC, "-"));
+	list_add(list, makeToken(OPKEY_ARITHMETIC_MINUS));
 
 	list_add(list, makeToken2(INTEGER, "5"));
 
 	list_add(list, makeToken(RPARENS));
 
-	list_add(list, makeToken2(OPKEY_ARITHMETIC, "*"));
+	list_add(list, makeToken(OPKEY_ARITHMETIC_MUL));
 
 	list_add(list, makeToken2(ID, "n"));
 

--- a/parser/test/astnodes/statements/StmtTest.c
+++ b/parser/test/astnodes/statements/StmtTest.c
@@ -19,11 +19,11 @@ int stmt_test_assignment_statement_with_struct_access() {
 
 	struct TokenList* tokens = makeTokenList();
 	list_add(tokens, makeToken2(ID, "x"));
-	list_add(tokens, makeToken2(STRUCTMEMBERACCESS, "."));
+	list_add(tokens, makeToken(STRUCTMEMBERACCESS));
 	list_add(tokens, makeToken2(ID, "a"));
-	list_add(tokens, makeToken2(ASSIGNOP, "="));
+	list_add(tokens, makeToken(ASSIGNOP_SIMPLE));
 	list_add(tokens, makeToken2(INTEGER, "3"));
-	list_add(tokens, makeToken2(SEMICOLON, ";"));
+	list_add(tokens, makeToken(SEMICOLON));
 
 	struct Stmt* node = makeStmt(tokens);
 

--- a/parser/test/astnodes/statements/WhileStmtTest.c
+++ b/parser/test/astnodes/statements/WhileStmtTest.c
@@ -24,7 +24,7 @@ int whilestmt_test1() {
 	list_add(list, makeToken(LPARENS));
 
 	list_add(list, makeToken2(INTEGER, "5"));
-	list_add(list, makeToken2(OPKEY_RELATIONAL, "<"));
+	list_add(list, makeToken(OPKEY_RELATIONAL_LT));
 	list_add(list, makeToken2(INTEGER, "3"));
 
 	list_add(list, makeToken(RPARENS));
@@ -56,7 +56,7 @@ int whilestmt_test2() {
 	list_add(list, makeToken(LPARENS));
 
 	list_add(list, makeToken2(INTEGER, "x"));
-	list_add(list, makeToken2(OPKEY_RELATIONAL, "<"));
+	list_add(list, makeToken(OPKEY_RELATIONAL_LT));
 	list_add(list, makeToken2(INTEGER, "4"));
 
 	list_add(list, makeToken(RPARENS));

--- a/parser/test/astnodes/struct/StructMemberTest.c
+++ b/parser/test/astnodes/struct/StructMemberTest.c
@@ -23,7 +23,7 @@ int structmember_test_can_parse_struct_member() {
 	list_add(list, makeToken2(LPARENS, "("));
 	list_add(list, makeToken2(TYPEID, "MyStruct"));
 	list_add(list, makeToken2(RPARENS, ")"));
-	list_add(list, makeToken2(ARROW, "->"));
+	list_add(list, makeToken(ARROW_NO_SIDE_EFFECT));
 	list_add(list, makeToken2(TYPEID, "Carrot"));
 	list_add(list, makeToken2(RPARENS, ")"));
 

--- a/parser/test/astnodes/subr/DeclArgTest.c
+++ b/parser/test/astnodes/subr/DeclArgTest.c
@@ -23,7 +23,7 @@ int declarg_test_parse_declared_argument() {
 	list_add(list, makeToken2(LPARENS, "("));
 	list_add(list, makeToken2(TYPEID, "Car"));
 	list_add(list, makeToken2(RPARENS, ")"));
-	list_add(list, makeToken2(ARROW, "->"));
+	list_add(list, makeToken(ARROW_NO_SIDE_EFFECT));
 	list_add(list, makeToken2(TYPEID, "Carrot"));
 	list_add(list, makeToken2(RPARENS, ")"));
 

--- a/parser/test/astnodes/subr/MethodTest.c
+++ b/parser/test/astnodes/subr/MethodTest.c
@@ -27,7 +27,7 @@ int method_test_can_parse_method_with_arguments() {
 	list_add(l, makeToken2(ID, "hello"));
 	list_add(l, makeToken(RPARENS));
 
-	list_add(l, makeToken2(ARROW, "->"));
+	list_add(l, makeToken(ARROW_NO_SIDE_EFFECT));
 	list_add(l, makeToken2(TYPEID, "Car"));
 
 	list_add(l, makeToken(LCURLY));
@@ -55,27 +55,27 @@ int method_test_can_parse_subroutine() {
 
 	struct TokenList* l = makeTokenList();
 
-	list_add(l, makeToken2(FN, "fn"));
+	list_add(l, makeToken(FN));
 	list_add(l, makeToken2(ID, "main"));
 
-	list_add(l, makeToken2(LPARENS, "("));
-	list_add(l, makeToken2(RPARENS, ")"));
+	list_add(l, makeToken(LPARENS));
+	list_add(l, makeToken(RPARENS));
 
-	list_add(l, makeToken2(ARROW, "~>"));
+	list_add(l, makeToken(ARROW_SIDE_EFFECT));
 	list_add(l, makeToken2(TYPEID, "Apple"));
 
-	list_add(l, makeToken2(LCURLY, "{"));
+	list_add(l, makeToken(LCURLY));
 
 	list_add(l, makeToken2(ID, "println"));
-	list_add(l, makeToken2(LPARENS, "("));
-	list_add(l, makeToken2(RPARENS, ")"));
-	list_add(l, makeToken2(SEMICOLON, ";"));
+	list_add(l, makeToken(LPARENS));
+	list_add(l, makeToken(RPARENS));
+	list_add(l, makeToken(SEMICOLON));
 
-	list_add(l, makeToken2(RETURN, "return"));
+	list_add(l, makeToken(RETURN));
 	list_add(l, makeToken2(INTEGER, "0"));
-	list_add(l, makeToken2(SEMICOLON, ";"));
+	list_add(l, makeToken(SEMICOLON));
 
-	list_add(l, makeToken2(RCURLY, "}"));
+	list_add(l, makeToken(RCURLY));
 
 	struct Method* m = makeMethod(l);
 	assert(m != NULL);
@@ -94,19 +94,19 @@ int method_test_can_parse_method_without_arguments() {
 
 	struct TokenList* l = makeTokenList();
 
-	list_add(l, makeToken2(FN, "fn"));
+	list_add(l, makeToken(FN));
 	list_add(l, makeToken2(ID, "main"));
 
-	list_add(l, makeToken2(LPARENS, "("));
-	list_add(l, makeToken2(RPARENS, ")"));
+	list_add(l, makeToken(LPARENS));
+	list_add(l, makeToken(RPARENS));
 
-	list_add(l, makeToken2(ARROW, "->"));
+	list_add(l, makeToken(ARROW_NO_SIDE_EFFECT));
 
 	list_add(l, makeToken2(TYPEID, "MyType"));
 
-	list_add(l, makeToken2(LCURLY, "{"));
+	list_add(l, makeToken(LCURLY));
 
-	list_add(l, makeToken2(RCURLY, "}"));
+	list_add(l, makeToken(RCURLY));
 
 	struct Method* m = makeMethod(l);
 	assert(m != NULL);

--- a/parser/test/astnodes/types/SubrTypeTest.c
+++ b/parser/test/astnodes/types/SubrTypeTest.c
@@ -25,7 +25,7 @@ int subrtype_test_typename() {
 	list_add(l, makeToken(COMMA));
 	list_add(l, makeToken2(TYPEID, "Carrot"));
 	list_add(l, makeToken(RPARENS));
-	list_add(l, makeToken2(ARROW, "->"));
+	list_add(l, makeToken(ARROW_NO_SIDE_EFFECT));
 	list_add(l, makeToken2(TYPEID, "MyStruct"));
 
 	struct SubrType* sub = makeSubrType(l);
@@ -52,14 +52,14 @@ int subrtype_test_typename_subroutine_return_type() {
 	list_add(l, makeToken2(TYPEID, "uint"));
 	list_add(l, makeToken(RPARENS));
 
-	list_add(l, makeToken2(ARROW, "->"));
+	list_add(l, makeToken(ARROW_NO_SIDE_EFFECT));
 
 	list_add(l, makeToken(LPARENS));
 	list_add(l, makeToken(LPARENS));
 	list_add(l, makeToken2(TYPEID, "uint"));
 	list_add(l, makeToken(RPARENS));
 
-	list_add(l, makeToken2(ARROW, "->"));
+	list_add(l, makeToken(ARROW_NO_SIDE_EFFECT));
 	list_add(l, makeToken2(TYPEID, "uint"));
 	list_add(l, makeToken(RPARENS));
 
@@ -87,7 +87,7 @@ int subrtype_test_subroutine_type_parsing_subroutine_with_side_effects() {
 	list_add(l, makeToken2(TYPEID, "MyType"));
 	list_add(l, makeToken(RPARENS));
 
-	list_add(l, makeToken2(ARROW, "->"));
+	list_add(l, makeToken(ARROW_NO_SIDE_EFFECT));
 
 	list_add(l, makeToken2(TYPEID, "uint"));
 
@@ -111,7 +111,7 @@ int subrtype_test_subroutine_type_parsing_subroutine_without_side_effects() {
 	list_add(l, makeToken(LPARENS));
 	list_add(l, makeToken2(TYPEID, "uint"));
 	list_add(l, makeToken(RPARENS));
-	list_add(l, makeToken2(ARROW, "->"));
+	list_add(l, makeToken(ARROW_NO_SIDE_EFFECT));
 	list_add(l, makeToken2(TYPEID, "uint"));
 
 	struct SubrType* node = makeSubrType(l);

--- a/token/TokenKeys.h
+++ b/token/TokenKeys.h
@@ -27,22 +27,43 @@
 #define TYPEID_PRIMITIVE_UINT64 18
 
 //()[]{}
-#define LPARENS 20
-#define RPARENS 21
-#define LBRACKET 22
-#define RBRACKET 23
-#define LCURLY 24
-#define RCURLY 25
+#define LPARENS 19
+#define RPARENS 20
+#define LBRACKET 21
+#define RBRACKET 22
+#define LCURLY 23
+#define RCURLY 24
 
-//Other
-#define ARROW 30
-#define ANYTYPE 31
-#define WAVE 33
-#define SEMICOLON 34
-//#define EQ 		35
-#define RANGEOP 36
-#define STRUCTMEMBERACCESS 37
-#define ASSIGNOP 38
+// ->
+#define ARROW_NO_SIDE_EFFECT 25
+// ~>
+#define ARROW_SIDE_EFFECT 26
+
+// #
+#define ANYTYPE 27
+// ~
+#define WAVE 28
+// ;
+#define SEMICOLON 29
+// ..
+#define RANGEOP 30
+// .
+#define STRUCTMEMBERACCESS 31
+
+// +=
+#define ASSIGNOP_PLUS 32
+// -=
+#define ASSIGNOP_MINUS 33
+// <<=
+#define ASSIGNOP_SHIFT_LEFT 34
+// >>=
+#define ASSIGNOP_SHIFT_RIGHT 35
+// &=
+#define ASSIGNOP_BITWISE_AND 36
+// |=
+#define ASSIGNOP_BITWISE_OR 37
+// '='
+#define ASSIGNOP_SIMPLE 38
 
 //Constants
 #define INTEGER 41
@@ -76,10 +97,43 @@
 #define INCLUDE_DECL 70
 
 //operator groups
-#define OPKEY_ARITHMETIC 80
-#define OPKEY_RELATIONAL 81
-#define OPKEY_LOGICAL 82
-#define OPKEY_BITWISE 83
+#define OPKEY_ARITHMETIC_PLUS 71
+#define OPKEY_ARITHMETIC_MINUS 72
+#define OPKEY_ARITHMETIC_MUL 73
+#define OPKEY_ARITHMETIC_DIV 74
+
+// ==
+#define OPKEY_RELATIONAL_EQ 75
+// !=
+#define OPKEY_RELATIONAL_NEQ 76
+// <
+#define OPKEY_RELATIONAL_LT 77
+// >
+#define OPKEY_RELATIONAL_GT 78
+// <=
+#define OPKEY_RELATIONAL_LE 79
+// >=
+#define OPKEY_RELATIONAL_GE 80
+
+// &&
+#define OPKEY_LOGICAL_AND 81
+// ||
+#define OPKEY_LOGICAL_OR 82
+// !
+#define OPKEY_LOGICAL_NOT 83
+
+// |
+#define OPKEY_BITWISE_OR 84
+// &
+#define OPKEY_BITWISE_AND 85
+// ^
+#define OPKEY_BITWISE_XOR 86
+// ~
+#define OPKEY_BITWISE_NOT 87
+// <<
+#define OPKEY_BITWISE_SHIFT_LEFT 88
+// >>
+#define OPKEY_BITWISE_SHIFT_RIGHT 89
 
 //annotations
 #define _ANNOT_START_ 90

--- a/token/reader/token_reader.c
+++ b/token/reader/token_reader.c
@@ -49,6 +49,97 @@ struct TokenList* read_tokens_from_tokens_file(FILE* file, char* tokensFile) {
 	return tks;
 }
 
+static struct Token* recognizeTokenInnerNoStr(int tkn_id) {
+
+	struct Token* r = NULL;
+
+	switch (tkn_id) {
+		case ANYTYPE:
+		//CONSTANTS
+		case BCONST_TRUE:
+		case BCONST_FALSE:
+		//BRACKETS, BRACES, PARENTHESES
+		case LBRACKET:
+		case RBRACKET:
+		case LPARENS:
+		case RPARENS:
+		case LCURLY:
+		case RCURLY:
+
+		case TYPEID_PRIMITIVE_INT:
+		case TYPEID_PRIMITIVE_UINT:
+		case TYPEID_PRIMITIVE_INT8:
+		case TYPEID_PRIMITIVE_UINT8:
+		case TYPEID_PRIMITIVE_INT16:
+		case TYPEID_PRIMITIVE_UINT16:
+		case TYPEID_PRIMITIVE_BOOL:
+		case TYPEID_PRIMITIVE_CHAR:
+
+		//SECTION: OPERATORNS
+		case OPKEY_ARITHMETIC_PLUS:
+		case OPKEY_ARITHMETIC_MINUS:
+		case OPKEY_ARITHMETIC_MUL:
+		case OPKEY_ARITHMETIC_DIV:
+		case OPKEY_RELATIONAL_EQ:
+		case OPKEY_RELATIONAL_NEQ:
+		case OPKEY_RELATIONAL_LT:
+		case OPKEY_RELATIONAL_GT:
+		case OPKEY_RELATIONAL_LE:
+		case OPKEY_RELATIONAL_GE:
+		case OPKEY_LOGICAL_AND:
+		case OPKEY_LOGICAL_OR:
+		case OPKEY_LOGICAL_NOT:
+		case OPKEY_BITWISE_OR:
+		case OPKEY_BITWISE_AND:
+		case OPKEY_BITWISE_XOR:
+		case OPKEY_BITWISE_NOT:
+		case OPKEY_BITWISE_SHIFT_LEFT:
+		case OPKEY_BITWISE_SHIFT_RIGHT:
+
+		case ASSIGNOP_PLUS:
+		case ASSIGNOP_MINUS:
+		case ASSIGNOP_SHIFT_LEFT:
+		case ASSIGNOP_SHIFT_RIGHT:
+		case ASSIGNOP_BITWISE_AND:
+		case ASSIGNOP_BITWISE_OR:
+		case ASSIGNOP_SIMPLE:
+		//SECTION: OTHER
+		case SEMICOLON:
+		case COMMA:
+		case STRUCTMEMBERACCESS:
+
+		//SECTION: ANNOTATIONS
+		case ANNOT_HALTS:
+		case ANNOT_PRIVATE:
+		case ANNOT_PUBLIC:
+		case ANNOT_DEPRECATED:
+
+		//SECTION: KEYWORDS
+		case RETURN:
+		case FN:
+		case STRUCT:
+		case IF:
+		case ELSE:
+		case WHILE:
+		case BREAK:
+		case CONTINUE:
+		case FOR:
+		case IN:
+		case RANGEOP:
+		case WAVE:
+		case ARROW_NO_SIDE_EFFECT:
+		case ARROW_SIDE_EFFECT:
+			r = makeToken(tkn_id);
+			break;
+		default:
+			printf("unreconized token id : %d\n", tkn_id);
+			exit(1);
+			return NULL;
+	};
+
+	return r;
+}
+
 static struct Token* recognizeToken(char* tkn, bool* isLineNo, uint32_t* line_num) {
 
 	char part1[10];
@@ -56,7 +147,15 @@ static struct Token* recognizeToken(char* tkn, bool* isLineNo, uint32_t* line_nu
 
 	char* space_ptr = strchr(tkn, ' ');
 
-	if (space_ptr == NULL) { return NULL; }
+	if (space_ptr == NULL) {
+		const int tkn_id = atoi(tkn);
+		struct Token* r = recognizeTokenInnerNoStr(tkn_id);
+
+		if (r != NULL) {
+			r->line_num = *line_num;
+		}
+		return r;
+	}
 
 	const int space_index = space_ptr - tkn;
 
@@ -97,65 +196,17 @@ static struct Token* recognizeTokenInner(int tkn_id, char* tkn, char* part2) {
 			break;
 		case ANYTYPE:
 		//CONSTANTS
-		case BCONST_TRUE:
-		case BCONST_FALSE:
 		case INTEGER:
 		case HEXCONST:
 		case BINCONST:
-		//BRACKETS, BRACES, PARENTHESES
-		case LBRACKET:
-		case RBRACKET:
-		case LPARENS:
-		case RPARENS:
-		case LCURLY:
-		case RCURLY:
 		//IDENTIFIERS
 		case ID:
 		case TYPEID:
 
-		case TYPEID_PRIMITIVE_INT:
-		case TYPEID_PRIMITIVE_UINT:
-		case TYPEID_PRIMITIVE_INT8:
-		case TYPEID_PRIMITIVE_UINT8:
-		case TYPEID_PRIMITIVE_INT16:
-		case TYPEID_PRIMITIVE_UINT16:
-		case TYPEID_PRIMITIVE_BOOL:
-		case TYPEID_PRIMITIVE_CHAR:
-
-		//SECTION: OPERATORNS
-		case OPKEY_ARITHMETIC:
-		case OPKEY_RELATIONAL:
-		case OPKEY_LOGICAL:
-		case OPKEY_BITWISE:
-
-		case ASSIGNOP:
 		//SECTION: OTHER
 		case TPARAM:
-		case SEMICOLON:
-		case COMMA:
-		case ARROW:
-		case STRUCTMEMBERACCESS:
 
-		//SECTION: ANNOTATIONS
-		case ANNOT_HALTS:
-		case ANNOT_PRIVATE:
-		case ANNOT_PUBLIC:
-		case ANNOT_DEPRECATED:
-
-		//SECTION: KEYWORDS
-		case RETURN:
-		case FN:
-		case STRUCT:
-		case IF:
-		case ELSE:
-		case WHILE:
-		case BREAK:
-		case CONTINUE:
-		case FOR:
-		case IN:
 		case INCLUDE_DECL:
-		case RANGEOP:
-		case WAVE:
 			r = makeToken2(tkn_id, part2);
 			break;
 		default:


### PR DESCRIPTION
Many tokens still had a string attached to it to further distingush it. But this is not needed, they can be separate tokens.

This obsoletes much of the string manipulation in the parser, which can now directly compare the token kind (integer).