### PR TITLE
headers: remove #ifndef ... #define ... endif

### DIFF
--- a/ast/ast.h
+++ b/ast/ast.h
@@ -1,5 +1,4 @@
-#ifndef AST_H
-#define AST_H
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -66,5 +65,3 @@ struct StmtBlock {
 	uint16_t count;
 	struct Stmt** stmts;
 };
-
-#endif

--- a/ast/ast/ast_const.h
+++ b/ast/ast/ast_const.h
@@ -1,5 +1,4 @@
-#ifndef AST_CONST_H
-#define AST_CONST_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -23,5 +22,3 @@ struct StringConst {
 	struct ASTNode super;
 	char* value;
 };
-
-#endif

--- a/ast/ast/ast_expr.h
+++ b/ast/ast/ast_expr.h
@@ -1,5 +1,4 @@
-#ifndef AST_EXPR_H
-#define AST_EXPR_H
+#pragma once
 
 #include "../ast_declare.h"
 
@@ -69,5 +68,3 @@ struct MDirect {
 	// width of the load/store, in bytes
 	uint8_t load_store_width;
 };
-
-#endif

--- a/ast/ast/ast_stmts.h
+++ b/ast/ast/ast_stmts.h
@@ -1,5 +1,4 @@
-#ifndef AST_STMTS_H
-#define AST_STMTS_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -80,4 +79,3 @@ struct ForStmt {
 	struct Range* range;
 	struct StmtBlock* block;
 };
-#endif

--- a/ast/ast/ast_struct.h
+++ b/ast/ast/ast_struct.h
@@ -1,5 +1,4 @@
-#ifndef AST_STRUCT_H
-#define AST_STRUCT_H
+#pragma once
 
 #include "../ast_declare.h"
 
@@ -19,5 +18,3 @@ struct StructMember {
 	struct Type* type;
 	char* name;
 };
-
-#endif

--- a/ast/ast/ast_subr.h
+++ b/ast/ast/ast_subr.h
@@ -1,5 +1,4 @@
-#ifndef AST_SUBR_H
-#define AST_SUBR_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -33,5 +32,3 @@ struct Method {
 
 	struct StmtBlock* block;
 };
-
-#endif

--- a/ast/ast/ast_types.h
+++ b/ast/ast/ast_types.h
@@ -1,5 +1,4 @@
-#ifndef AST_TYPES_H
-#define AST_TYPES_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -70,5 +69,3 @@ struct TypeParam {
 
 	uint8_t index; /*type parameter index */
 };
-
-#endif

--- a/ast/ast/ast_var.h
+++ b/ast/ast/ast_var.h
@@ -1,5 +1,4 @@
-#ifndef AST_VAR_H
-#define AST_VAR_H
+#pragma once
 
 #include "../ast_declare.h"
 
@@ -17,5 +16,3 @@ struct SimpleVar {
 	uint8_t count_indices;
 	struct Expr** indices;
 };
-
-#endif

--- a/ast/ast_declare.h
+++ b/ast/ast_declare.h
@@ -1,5 +1,4 @@
-#ifndef AST_DECLARE_H
-#define AST_DECLARE_H
+#pragma once
 
 #include "token/TokenKeys.h"
 
@@ -75,5 +74,3 @@ struct ASTNode {
 };
 
 #define has_annotation(annotations, annotation) ((annotations) & (1 << ((annotation) - _ANNOT_START_))) != 0
-
-#endif

--- a/ast/sd_inttype.h
+++ b/ast/sd_inttype.h
@@ -1,5 +1,4 @@
-#ifndef SD_INTTYPE_H
-#define SD_INTTYPE_H
+#pragma once
 
 enum INTTYPE {
 
@@ -20,5 +19,3 @@ enum INTTYPE {
 
 	INTTYPE_END,
 };
-
-#endif

--- a/ast/test/test_str_ast.h
+++ b/ast/test/test_str_ast.h
@@ -1,5 +1,4 @@
-#ifndef TEST_STR_AST_H
-#define TEST_STR_AST_H
+#pragma once
 
 //const
 void test_ast_str_binconst();
@@ -16,5 +15,3 @@ void test_ast_str_term();
 //struct
 void test_ast_str_structdecl();
 void test_ast_str_structmember();
-
-#endif

--- a/ast/util/copy_ast.h
+++ b/ast/util/copy_ast.h
@@ -1,5 +1,4 @@
-#ifndef COPYAST
-#define COPYAST
+#pragma once
 
 #include "../ast.h"
 
@@ -50,5 +49,3 @@ struct Variable* copy_variable(struct Variable* var);
 struct Id* copy_identifier(struct Id* id);
 struct Range* copy_range(struct Range* r);
 struct StmtBlock* copy_stmt_block(struct StmtBlock* s);
-
-#endif

--- a/ast/util/equals_ast.h
+++ b/ast/util/equals_ast.h
@@ -1,5 +1,4 @@
-#ifndef EQUALS_AST_H
-#define EQUALS_AST_H
+#pragma once
 
 #include <stdbool.h>
 #include "../ast_declare.h"
@@ -26,5 +25,3 @@ bool eq_primitivetype(struct PrimitiveType* a, struct PrimitiveType* b);
 bool eq_basictype(struct BasicType* a, struct BasicType* b);
 
 bool eq_arraytype(struct ArrayType* a, struct ArrayType* b);
-
-#endif

--- a/ast/util/free_ast.h
+++ b/ast/util/free_ast.h
@@ -1,5 +1,4 @@
-#ifndef FREEAST
-#define FREEAST
+#pragma once
 
 #include "../ast.h"
 
@@ -65,5 +64,3 @@ void free_type(struct Type* t);
 void free_type_param(struct TypeParam* tp);
 void free_primitive_type(struct PrimitiveType* p);
 void free_struct_type(struct StructType* s);
-
-#endif

--- a/ast/util/str_ast.h
+++ b/ast/util/str_ast.h
@@ -1,5 +1,4 @@
-#ifndef STR_AST_H
-#define STR_AST_H
+#pragma once
 
 #include "../ast.h"
 
@@ -88,5 +87,3 @@ char* str_identifier(struct Id* id);
 char* str_range(struct Range* r);
 // @returns NULL on error
 char* str_stmt_block(struct StmtBlock* block);
-
-#endif

--- a/compiler/main/analyzer/annotation/annotation_analyzer.h
+++ b/compiler/main/analyzer/annotation/annotation_analyzer.h
@@ -1,5 +1,4 @@
-#ifndef LV_ANALYZER_H
-#define LV_ANALYZER_H
+#pragma once
 
 /* this Transpiler-Analyzer Module
  * can look for various Annotations
@@ -7,6 +6,7 @@
  * regarding those Annotations in their Context.
  */
 
-void analyze_annotations(struct ST* st, struct AST* ast);
+struct AST;
+struct ST;
 
-#endif
+void analyze_annotations(struct ST* st, struct AST* ast);

--- a/compiler/main/analyzer/dead/dead.h
+++ b/compiler/main/analyzer/dead/dead.h
@@ -1,5 +1,4 @@
-#ifndef DEAD_H
-#define DEAD_H
+#pragma once
 
 enum DEAD {
 
@@ -7,5 +6,3 @@ enum DEAD {
 	DEAD_ISDEAD,
 	DEAD_UNKNOWN
 };
-
-#endif

--- a/compiler/main/analyzer/dead/dead_analyzer.h
+++ b/compiler/main/analyzer/dead/dead_analyzer.h
@@ -1,5 +1,4 @@
-#ifndef DEAD_ANALYZER_H
-#define DEAD_ANALYZER_H
+#pragma once
 
 /* This is the dead code analyzer
  * it looks for functions not reachable from
@@ -11,5 +10,3 @@ struct ST;
 struct AST;
 
 void analyze_dead_code(struct ST* st, struct AST* ast);
-
-#endif

--- a/compiler/main/analyzer/fn/fn_analyzer.h
+++ b/compiler/main/analyzer/fn/fn_analyzer.h
@@ -1,5 +1,4 @@
-#ifndef FN_ANALYZER_H
-#define FN_ANALYZER_H
+#pragma once
 
 struct ST;
 struct AST;
@@ -14,5 +13,3 @@ struct AST;
  */
 
 void analyze_functions(struct ST* st, struct AST* ast);
-
-#endif

--- a/compiler/main/analyzer/halts/halt_analyzer.h
+++ b/compiler/main/analyzer/halts/halt_analyzer.h
@@ -1,5 +1,4 @@
-#ifndef HALT_ANALYZER_H
-#define HALT_ANALYZER_H
+#pragma once
 
 /* this Analyzer Module
  * can performa a termination analysis for
@@ -12,5 +11,3 @@
  */
 
 void analyze_termination(struct ST* st);
-
-#endif

--- a/compiler/main/analyzer/halts/halts.h
+++ b/compiler/main/analyzer/halts/halts.h
@@ -1,5 +1,4 @@
-#ifndef HALTS_H
-#define HALTS_H
+#pragma once
 
 /*
  * for some subroutines it is desired that they
@@ -27,5 +26,3 @@ enum HALTS {
 	HALTS_NEVER,
 	HALTS_UNKNOWN
 };
-
-#endif

--- a/compiler/main/analyzer/lv/lv_analyzer.h
+++ b/compiler/main/analyzer/lv/lv_analyzer.h
@@ -1,5 +1,4 @@
-#ifndef LV_ANALYZER_H
-#define LV_ANALYZER_H
+#pragma once
 
 /* this Transpiler-Analyzer Module
  * can discover the local variables of a function,
@@ -11,5 +10,3 @@ struct ST;
 struct Method;
 
 void lvst_fill(struct Method* subr, struct ST* st);
-
-#endif

--- a/compiler/main/avr_code_gen/cg_avr.h
+++ b/compiler/main/avr_code_gen/cg_avr.h
@@ -1,5 +1,4 @@
-#ifndef SMALLDRAGON_TOPLEVEL_CG_AVR_H
-#define SMALLDRAGON_TOPLEVEL_CG_AVR_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -13,5 +12,3 @@ void emit_call_main_endloop(struct IBuffer* ibu);
 //void emit_setup_stack_pointer_avr(FILE* fout);
 
 bool compile_and_write_avr(struct AST* ast, struct Ctx* ctx);
-
-#endif

--- a/compiler/main/avr_code_gen/cg_avr_basic_block.h
+++ b/compiler/main/avr_code_gen/cg_avr_basic_block.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -8,11 +9,6 @@
 #include "util/ctx.h"
 #include "basic_block/basicblock.h"
 
-#ifndef SMALLDRAGON_TOPLEVEL_CG_AVR_BASIC_BLOCK_H
-#define SMALLDRAGON_TOPLEVEL_CG_AVR_BASIC_BLOCK_H
-
 struct IBuffer;
 
 bool emit_asm_avr_basic_block(struct BasicBlock* block, struct Ctx* ctx, struct IBuffer* ibu);
-
-#endif

--- a/compiler/main/basic_block/basicblock.h
+++ b/compiler/main/basic_block/basicblock.h
@@ -1,5 +1,4 @@
-#ifndef SMALLDRAGON_TOPLEVEL_BASICBLOCK_H
-#define SMALLDRAGON_TOPLEVEL_BASICBLOCK_H
+#pragma once
 
 #include <inttypes.h>
 
@@ -26,5 +25,3 @@ void basicblock_print(struct BasicBlock* block, struct Ctx* ctx);
 
 // @returns NULL on error;
 struct BasicBlock** basicblock_create_graph(struct TACBuffer* buffer, char* function_name, int* nblocks, struct Ctx* ctx);
-
-#endif

--- a/compiler/main/basic_block/basicblock_printer.h
+++ b/compiler/main/basic_block/basicblock_printer.h
@@ -1,6 +1,3 @@
-#ifndef SMALLDRAGON_TOPLEVEL_BASICBLOCK_PRINTER_H
-#define SMALLDRAGON_TOPLEVEL_BASICBLOCK_PRINTER_H
+#pragma once
 
 void write_dot_file_from_graph(struct BasicBlock** blocks, uint32_t count, char* function_name, struct Ctx* ctx);
-
-#endif

--- a/compiler/main/cli/flags/flags.h
+++ b/compiler/main/cli/flags/flags.h
@@ -1,5 +1,4 @@
-#ifndef FLAGS
-#define FLAGS
+#pragma once
 
 #include <stdbool.h>
 #include <inttypes.h>
@@ -37,4 +36,3 @@ char* flags_asm_filename(struct Flags* ctx);
 char* flags_token_filename(struct Flags* ctx);
 char* flags_hex_filename(struct Flags* ctx);
 char* flags_obj_filename(struct Flags* ctx);
-#endif

--- a/compiler/main/derefll/derefll.h
+++ b/compiler/main/derefll/derefll.h
@@ -1,5 +1,4 @@
-#ifndef DEREFLL_H
-#define DEREFLL_H
+#pragma once
 
 //struct DerefLL
 //
@@ -56,5 +55,3 @@ struct DerefLL* derefll_structmember(char* name);
 struct DerefLL* derefll_expr(struct Expr* expr);
 
 void derefll_annotate_types(struct DerefLL* dll, struct Ctx* ctx, struct Type* prev_type);
-
-#endif

--- a/compiler/main/gen_tac/helper_gen_tac_derefll.h
+++ b/compiler/main/gen_tac/helper_gen_tac_derefll.h
@@ -1,5 +1,4 @@
-#ifndef HELPER_GEN_TAC_DEREFLL_H
-#define HELPER_GEN_TAC_DEREFLL_H
+#pragma once
 
 struct TACBuffer;
 struct DerefLL;
@@ -7,5 +6,3 @@ struct Type;
 struct Ctx;
 
 void tac_derefll_single(struct TACBuffer* buffer, struct DerefLL* dll, struct Type* prev_type, struct Ctx* ctx);
-
-#endif

--- a/compiler/main/invoke/invoke.h
+++ b/compiler/main/invoke/invoke.h
@@ -1,10 +1,7 @@
-#ifndef INVOKE_H
-#define INVOKE_H
+#pragma once
 
 #include <stdbool.h>
 struct Namespace;
 
 int invoke_lexer(char* filename);
 struct Namespace* invoke_parser(char* filename);
-
-#endif

--- a/compiler/main/typechecker/_tc.h
+++ b/compiler/main/typechecker/_tc.h
@@ -1,5 +1,4 @@
-#ifndef _TC_H
-#define _TC_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -46,5 +45,3 @@ bool tc_method(struct Method* m, struct TCCtx* tcctx);
 bool tc_namespace(struct Namespace* n, struct TCCtx* tcctx);
 
 bool tc_stmtblock(struct StmtBlock* s, struct TCCtx* tcctx);
-
-#endif

--- a/compiler/main/typechecker/tcctx.h
+++ b/compiler/main/typechecker/tcctx.h
@@ -1,5 +1,4 @@
-#ifndef TC_CTX_H
-#define TC_CTX_H
+#pragma once
 
 #include <inttypes.h>
 #include <stdbool.h>
@@ -71,5 +70,3 @@ struct TCCtx {
 
 	bool debug;
 };
-
-#endif

--- a/compiler/main/typechecker/type_contains/tc_type_contains.h
+++ b/compiler/main/typechecker/type_contains/tc_type_contains.h
@@ -1,5 +1,4 @@
-#ifndef SMALLDRAGON_TOPLEVEL_TC_TYPE_CONTAINS_H
-#define SMALLDRAGON_TOPLEVEL_TC_TYPE_CONTAINS_H
+#pragma once
 
 #include <stdbool.h>
 struct Type;
@@ -8,5 +7,3 @@ struct Type;
 //e.g. uint32 contains uint16
 //e.g. List<?T0> contains List<int>
 bool tc_type_contains(struct Type* expect, struct Type* actual);
-
-#endif

--- a/compiler/main/typechecker/typecheck.h
+++ b/compiler/main/typechecker/typecheck.h
@@ -1,5 +1,4 @@
-#ifndef TYPECHECK_H
-#define TYPECHECK_H
+#pragma once
 
 struct AST;
 struct ST;
@@ -28,5 +27,3 @@ struct ST;
 
 // @returns NULL on error
 struct TCError* typecheck_ast(struct AST* ast, struct Ctx* ctx, bool print_errors);
-
-#endif

--- a/compiler/main/typechecker/util/tc_errors.h
+++ b/compiler/main/typechecker/util/tc_errors.h
@@ -1,5 +1,4 @@
-#ifndef TYPECHECKING_ERRORS_H
-#define TYPECHECKING_ERRORS_H
+#pragma once
 
 struct TCCtx;
 enum TC_ERR_KIND;
@@ -9,5 +8,3 @@ void error(struct TCCtx* tcctx, char* msg, enum TC_ERR_KIND err_kind);
 void error_snippet(struct TCCtx* tcctx, char* snippet, enum TC_ERR_KIND err_kind);
 
 void error_snippet_and_msg(struct TCCtx* tcctx, char* snippet, char* msg, enum TC_ERR_KIND err_kind);
-
-#endif

--- a/compiler/main/typechecker/util/tc_utils.h
+++ b/compiler/main/typechecker/util/tc_utils.h
@@ -1,5 +1,4 @@
-#ifndef TYPECHECKING_UTILS_H
-#define TYPECHECKING_UTILS_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -12,5 +11,3 @@ bool is_bool_type(struct Type* type);
 bool is_char_type(struct Type* type);
 
 uint32_t max_indices_allowed(struct Type* type);
-
-#endif

--- a/compiler/main/typeinference/typeinfer.h
+++ b/compiler/main/typeinference/typeinfer.h
@@ -1,5 +1,4 @@
-#ifndef TYPEINFERENCE_H
-#define TYPEINFERENCE_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -47,5 +46,3 @@ struct Type* infer_in_context(struct ST* st, struct MemberAccess* ma);
 
 // @returns the member type after one level of member access and indices
 struct Type* infer_in_context_once(struct ST* st, struct MemberAccess* ma);
-
-#endif

--- a/compiler/main/typeinference/util/type_str.h
+++ b/compiler/main/typeinference/util/type_str.h
@@ -1,5 +1,4 @@
-#ifndef TYPE_STR_H
-#define TYPE_STR_H
+#pragma once
 
 #include "ast/ast.h"
 
@@ -13,5 +12,3 @@ struct Type* typeFromStrArray(struct ST* st, char* typeName);
  *	as this pointer is not part of the AST Tree
  */
 void registerInferredType(struct ST* st, struct Type* t);
-
-#endif

--- a/compiler/main/util/ctx.h
+++ b/compiler/main/util/ctx.h
@@ -1,5 +1,4 @@
-#ifndef CTX
-#define CTX
+#pragma once
 
 #include <stdio.h>
 #include <inttypes.h>
@@ -28,4 +27,3 @@ int32_t ctx_get_label_loop_start(struct Ctx* ctx);
 
 // @returns < 0 on error
 int32_t ctx_get_label_loop_end(struct Ctx* ctx);
-#endif

--- a/compiler/main/util/fileutils/fileutils.h
+++ b/compiler/main/util/fileutils/fileutils.h
@@ -1,7 +1,5 @@
-#ifndef FILEUTILS_H
-#define FILEUTILS_H
+#pragma once
 
 #include "cli/flags/flags.h"
 
 bool check_filenames_lowercase(struct Flags* flags);
-#endif

--- a/compiler/main/util/fill_tables.h
+++ b/compiler/main/util/fill_tables.h
@@ -1,9 +1,6 @@
-#ifndef SMALLDRAGON_TOPLEVEL_FILL_TABLES_H
-#define SMALLDRAGON_TOPLEVEL_FILL_TABLES_H
+#pragma once
 
 struct AST;
 struct Ctx;
 
 void fill_tables(struct AST* ast, struct Ctx* ctx);
-
-#endif

--- a/compiler/test/avr_code_gen/compile_ir/test_compile_tac.h
+++ b/compiler/test/avr_code_gen/compile_ir/test_compile_tac.h
@@ -1,5 +1,4 @@
-#ifndef TEST_COMPILE_TAC_H
-#define TEST_COMPILE_TAC_H
+#pragma once
 
 #include "libvmcu_utils/libvmcu_utils.h"
 
@@ -118,5 +117,3 @@ void test_compile_tac_setup_sp();
 
 // TAC_SETUP_STACKFRAME
 void test_compile_tac_setup_stackframe();
-
-#endif

--- a/compiler/test/avr_code_gen/test_avr_code_gen_util.h
+++ b/compiler/test/avr_code_gen/test_avr_code_gen_util.h
@@ -1,5 +1,4 @@
-#ifndef SMALLDRAGON_TOPLEVEL_TEST_AVR_CODE_GEN_UTIL_H
-#define SMALLDRAGON_TOPLEVEL_TEST_AVR_CODE_GEN_UTIL_H
+#pragma once
 
 #include "../../../dependencies/libvmcu-Virtual-MCU-Library/engine/include/libvmcu/libvmcu_system.h"
 struct TACBuffer;
@@ -19,5 +18,3 @@ vmcu_system_t* prepare_vmcu_system_from_tacbuffer_with_redzone(struct TACBuffer*
 
 // assert that the values around the address still have 'redzone' value
 void assert_redzone(vmcu_system_t* system, uint16_t addr, uint8_t width, uint8_t redzone);
-
-#endif

--- a/compiler/test/avr_code_gen/timer/test_avr_code_gen_timer.h
+++ b/compiler/test/avr_code_gen/timer/test_avr_code_gen_timer.h
@@ -1,6 +1,3 @@
-#ifndef SD_AVR_CODE_GEN_TEST_TIMER
-#define SD_AVR_CODE_GEN_TEST_TIMER
+#pragma once
 
 void test_avr_code_gen_timer();
-
-#endif

--- a/compiler/test/libvmcu_utils/libvmcu_utils.h
+++ b/compiler/test/libvmcu_utils/libvmcu_utils.h
@@ -1,5 +1,4 @@
-#ifndef LIBVMCU_UTILS_H
-#define LIBVMCU_UTILS_H
+#pragma once
 
 //utilities for testing with libvmcu.
 
@@ -22,5 +21,3 @@ uint16_t vmcu_system_read_data16(vmcu_system_t* system, uint16_t addr);
 
 // read 16 bit value from 2 adjacent gprs
 uint16_t vmcu_system_read_2_gpr(vmcu_system_t* system, const int low_reg);
-
-#endif

--- a/compiler/test/typeinference/test_typeinference_util.h
+++ b/compiler/test/typeinference/test_typeinference_util.h
@@ -1,6 +1,3 @@
-#ifndef SMALLDRAGON_TEST_TYPEINFERENCE_UTIL_H
-#define SMALLDRAGON_TEST_TYPEINFERENCE_UTIL_H
+#pragma once
 
 struct Type* typeinfer_in_file(char* filename);
-
-#endif

--- a/compiler/test/x86_code_gen/test_x86_code_gen_util.c
+++ b/compiler/test/x86_code_gen/test_x86_code_gen_util.c
@@ -1,5 +1,7 @@
 #include <assert.h>
 #include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <sys/mman.h>
 #include <sys/stat.h>

--- a/ibuffer/ibuffer_write.h
+++ b/ibuffer/ibuffer_write.h
@@ -1,5 +1,4 @@
-#ifndef IBUFFER_WRITE_H
-#define IBUFFER_WRITE_H
+#pragma once
 
 #include <inttypes.h>
 
@@ -7,5 +6,3 @@
 #include "ikey.h"
 
 void ibu_write_instr(enum IKEY key, int32_t x1, int32_t x2, int32_t x3, char* str, char* comment, FILE* fout);
-
-#endif

--- a/ibuffer/ikey.h
+++ b/ibuffer/ikey.h
@@ -1,5 +1,4 @@
-#ifndef IKEY_H
-#define IKEY_H
+#pragma once
 
 //IKEY meaning Instruction Key
 enum IKEY {
@@ -240,5 +239,3 @@ enum IKEY {
 	X86_NOP,
 	// END   --- X86 Instructions --
 };
-
-#endif

--- a/lexer/src/driver.h
+++ b/lexer/src/driver.h
@@ -1,5 +1,4 @@
-#ifndef DRIVER
-#define DRIVER
+#pragma once
 
 #include <stdio.h>
 #include <stdbool.h>
@@ -17,5 +16,3 @@ void out_minus_minus(FILE* outFile);
 struct LexerFlags* handle_arguments(int argc, char** argv);
 
 char* lexer_make_tkn_filename(char* filename);
-
-#endif

--- a/lexer/src/lexer_flags.h
+++ b/lexer/src/lexer_flags.h
@@ -1,5 +1,4 @@
-#ifndef LEXER_FLAGS
-#define LEXER_FLAGS
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct LexerFlags {
 
 	char* filename;
 };
-
-#endif

--- a/lexer/test/test.h
+++ b/lexer/test/test.h
@@ -1,5 +1,4 @@
-#ifndef LEXERTEST
-#define LEXERTEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -89,4 +88,3 @@ void test_multi_line_comment();
 
 // tests_include_decl.h
 void test_include_decl();
-#endif

--- a/parser/main/astnodes/Identifier.h
+++ b/parser/main/astnodes/Identifier.h
@@ -1,5 +1,4 @@
-#ifndef IDENTIFIER
-#define IDENTIFIER
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct Id;
 struct TokenList;
 
 struct Id* makeIdentifier(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/Namespace.h
+++ b/parser/main/astnodes/Namespace.h
@@ -1,9 +1,6 @@
-#ifndef NAMESPACE
-#define NAMESPACE
+#pragma once
 
 struct TokenList;
 struct Namespace;
 
 struct Namespace* makeNamespace(struct TokenList* tokens, char* name);
-
-#endif

--- a/parser/main/astnodes/Range.h
+++ b/parser/main/astnodes/Range.h
@@ -1,9 +1,6 @@
-#ifndef RANGE
-#define RANGE
+#pragma once
 
 struct TokenList;
 struct Range;
 
 struct Range* makeRange(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/StmtBlock.h
+++ b/parser/main/astnodes/StmtBlock.h
@@ -1,5 +1,4 @@
-#ifndef STMTBLOCK
-#define STMTBLOCK
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct StmtBlock;
 
 struct StmtBlock* makeStmtBlock(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/const/ConstValue.h
+++ b/parser/main/astnodes/const/ConstValue.h
@@ -1,5 +1,4 @@
-#ifndef CONSTVALUE_H
-#define CONSTVALUE_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct ConstValue;
 struct TokenList;
 
 struct ConstValue* makeConstValue(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/const/IntConst.h
+++ b/parser/main/astnodes/const/IntConst.h
@@ -1,5 +1,4 @@
-#ifndef INTCONST
-#define INTCONST
+#pragma once
 
 #include <stdbool.h>
 #include <inttypes.h>
@@ -7,5 +6,3 @@
 struct TokenList;
 
 int32_t makeIntConst(struct TokenList* tokens, bool* error);
-
-#endif

--- a/parser/main/astnodes/expr/Expr.h
+++ b/parser/main/astnodes/expr/Expr.h
@@ -1,5 +1,4 @@
-#ifndef EXPR
-#define EXPR
+#pragma once
 
 #include <string.h>
 #include <stdbool.h>
@@ -21,5 +20,3 @@ int prec_index(enum OP op);
 void** insert(void** arr, int index, void* element, int size_before);
 
 void** erase(void** arr, int index, int size_before);
-
-#endif

--- a/parser/main/astnodes/expr/MDirect.h
+++ b/parser/main/astnodes/expr/MDirect.h
@@ -1,9 +1,6 @@
-#ifndef SMALLDRAGON_TOPLEVEL_MDIRECT_H
-#define SMALLDRAGON_TOPLEVEL_MDIRECT_H
+#pragma once
 
 struct MDirect;
 struct TokenList;
 
 struct MDirect* makeMDirect(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/expr/Op.h
+++ b/parser/main/astnodes/expr/Op.h
@@ -1,9 +1,6 @@
-#ifndef OP_H
-#define OP_H
+#pragma once
 
 struct TokenList;
 enum OP;
 
 enum OP makeOp(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/expr/Term.h
+++ b/parser/main/astnodes/expr/Term.h
@@ -1,5 +1,4 @@
-#ifndef TERM
-#define TERM
+#pragma once
 
 struct TokenList;
 struct Term;
@@ -7,5 +6,3 @@ struct Expr;
 
 struct Term* makeTerm_other(struct Expr* myexpr);
 struct Term* makeTerm(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/expr/UnOpTerm.h
+++ b/parser/main/astnodes/expr/UnOpTerm.h
@@ -1,5 +1,4 @@
-#ifndef VARIABLE
-#define VARIABLE
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct UnOpTerm;
 
 struct UnOpTerm* makeUnOpTerm(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/statements/AssignStmt.h
+++ b/parser/main/astnodes/statements/AssignStmt.h
@@ -1,5 +1,4 @@
-#ifndef ASSIGNSTMT
-#define ASSIGNSTMT
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct AssignStmt;
 
 struct AssignStmt* makeAssignStmt(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/statements/Call.h
+++ b/parser/main/astnodes/statements/Call.h
@@ -1,5 +1,4 @@
-#ifndef CALL_H
-#define CALL_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct Call;
 
 struct Call* makeCall(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/statements/ForStmt.h
+++ b/parser/main/astnodes/statements/ForStmt.h
@@ -1,5 +1,4 @@
-#ifndef FORSTMT
-#define FORSTMT
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct ForStmt;
 
 struct ForStmt* makeForStmt(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/statements/IfStmt.h
+++ b/parser/main/astnodes/statements/IfStmt.h
@@ -1,5 +1,4 @@
-#ifndef IFSTMT
-#define IFSTMT
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct IfStmt;
 
 struct IfStmt* makeIfStmt(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/statements/MAssignStmt.h
+++ b/parser/main/astnodes/statements/MAssignStmt.h
@@ -1,5 +1,4 @@
-#ifndef SMALLDRAGON_TOPLEVEL_MASSIGNSTMT_H
-#define SMALLDRAGON_TOPLEVEL_MASSIGNSTMT_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct MAssignStmt;
 
 struct MAssignStmt* makeMAssignStmt(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/statements/RetStmt.h
+++ b/parser/main/astnodes/statements/RetStmt.h
@@ -1,5 +1,4 @@
-#ifndef RETURNSTMT
-#define RETURNSTMT
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct RetStmt;
 
 struct RetStmt* makeRetStmt(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/statements/Stmt.h
+++ b/parser/main/astnodes/statements/Stmt.h
@@ -1,5 +1,4 @@
-#ifndef STMT
-#define STMT
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct Stmt;
 
 struct Stmt* makeStmt(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/statements/WhileStmt.h
+++ b/parser/main/astnodes/statements/WhileStmt.h
@@ -1,5 +1,4 @@
-#ifndef WHILESTMT
-#define WHILESTMT
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct WhileStmt;
 
 struct WhileStmt* makeWhileStmt(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/struct/StructDecl.h
+++ b/parser/main/astnodes/struct/StructDecl.h
@@ -1,9 +1,6 @@
-#ifndef STRUCTDECL
-#define STRUCTDECL
+#pragma once
 
 struct TokenList;
 struct StructDecl;
 
 struct StructDecl* makeStructDecl(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/struct/StructMember.h
+++ b/parser/main/astnodes/struct/StructMember.h
@@ -1,9 +1,6 @@
-#ifndef STRUCTMEMBER
-#define STRUCTMEMBER
+#pragma once
 
 struct TokenList;
 struct StructMember;
 
 struct StructMember* makeStructMember(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/subr/DeclArg.h
+++ b/parser/main/astnodes/subr/DeclArg.h
@@ -1,5 +1,4 @@
-#ifndef DECLARG
-#define DECLARG
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct DeclArg;
 struct TokenList;
 
 struct DeclArg* makeDeclArg(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/subr/Method.h
+++ b/parser/main/astnodes/subr/Method.h
@@ -1,5 +1,4 @@
-#ifndef METHOD
-#define METHOD
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct Method;
 
 struct Method* makeMethod(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/subr/MethodDecl.h
+++ b/parser/main/astnodes/subr/MethodDecl.h
@@ -1,9 +1,6 @@
-#ifndef SMALLDRAGON_TOPLEVEL_METHODDECL_H
-#define SMALLDRAGON_TOPLEVEL_METHODDECL_H
+#pragma once
 
 struct MethodDecl;
 struct TokenList;
 
 struct MethodDecl* makeMethodDecl(struct TokenList* tokens);
-
-#endif //SMALLDRAGON_TOPLEVEL_METHODDECL_H

--- a/parser/main/astnodes/types/ArrayType.h
+++ b/parser/main/astnodes/types/ArrayType.h
@@ -1,5 +1,4 @@
-#ifndef ARRAYTYPE
-#define ARRAYTYPE
+#pragma once
 
 #include <stdbool.h>
 
@@ -9,5 +8,3 @@ struct ArrayType;
 
 struct ArrayType* makeArrayType(struct Type* element_type);
 struct ArrayType* makeArrayType2(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/types/BasicType.h
+++ b/parser/main/astnodes/types/BasicType.h
@@ -1,5 +1,4 @@
-#ifndef BASICTYPE_H
-#define BASICTYPE_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -11,5 +10,3 @@ struct SubrType;
 struct BasicType* makeBasicTypeSimple(struct SimpleType* typeNode);
 struct BasicType* makeBasicTypeSubr(struct SubrType* typeNode);
 struct BasicType* makeBasicType2(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/types/PrimitiveType.h
+++ b/parser/main/astnodes/types/PrimitiveType.h
@@ -1,5 +1,4 @@
-#ifndef PRIMITIVETYPE_H
-#define PRIMITIVETYPE_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct PrimitiveType;
 
 struct PrimitiveType* makePrimitiveType(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/types/SimpleType.h
+++ b/parser/main/astnodes/types/SimpleType.h
@@ -1,5 +1,4 @@
-#ifndef SIMPLETYPE
-#define SIMPLETYPE
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct SimpleType;
 
 struct SimpleType* makeSimpleType(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/types/StructType.h
+++ b/parser/main/astnodes/types/StructType.h
@@ -1,5 +1,4 @@
-#ifndef STRUCTTYPE_H
-#define STRUCTTYPE_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -8,5 +7,3 @@ struct StructType;
 
 // @returns NULL on error
 struct StructType* makeStructType(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/types/SubrType.h
+++ b/parser/main/astnodes/types/SubrType.h
@@ -1,5 +1,4 @@
-#ifndef SUBROUTINETYPE
-#define SUBROUTINETYPE
+#pragma once
 
 #include <stdbool.h>
 
@@ -8,5 +7,3 @@ struct Type;
 struct SubrType;
 
 struct SubrType* makeSubrType(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/types/Type.h
+++ b/parser/main/astnodes/types/Type.h
@@ -1,5 +1,4 @@
-#ifndef TYPE
-#define TYPE
+#pragma once
 
 #include <stdbool.h>
 
@@ -13,5 +12,3 @@ struct Type* makeType2(struct TokenList* tokens);
 struct Type* makeType_1(struct BasicType* typeNode);
 struct Type* makeType_2(struct TypeParam* typeNode);
 struct Type* makeType_3(struct ArrayType* typeNode);
-
-#endif

--- a/parser/main/astnodes/types/TypeParam.h
+++ b/parser/main/astnodes/types/TypeParam.h
@@ -1,5 +1,4 @@
-#ifndef TYPEPARAM
-#define TYPEPARAM
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ struct TokenList;
 struct TypeParam;
 
 struct TypeParam* makeTypeParam(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/var/SimpleVar.h
+++ b/parser/main/astnodes/var/SimpleVar.h
@@ -1,9 +1,6 @@
-#ifndef SIMPLEVAR
-#define SIMPLEVAR
+#pragma once
 
 struct TokenList;
 struct SimpleVar;
 
 struct SimpleVar* makeSimpleVar(struct TokenList* tokens);
-
-#endif

--- a/parser/main/astnodes/var/Variable.h
+++ b/parser/main/astnodes/var/Variable.h
@@ -1,5 +1,4 @@
-#ifndef VARIABLE
-#define VARIABLE
+#pragma once
 
 #include <stdbool.h>
 
@@ -8,5 +7,3 @@ struct Variable;
 
 // @returns NULL on error
 struct Variable* makeVariable(struct TokenList* tokens);
-
-#endif

--- a/parser/main/util/parse_astnode.h
+++ b/parser/main/util/parse_astnode.h
@@ -1,9 +1,6 @@
-#ifndef PARSE_ASTNODE_H
-#define PARSE_ASTNODE_H
+#pragma once
 
 struct TokenList;
 struct ASTNode;
 
 void parse_astnode(struct TokenList* tknList, struct ASTNode* node);
-
-#endif

--- a/parser/main/util/parser.h
+++ b/parser/main/util/parser.h
@@ -1,6 +1,4 @@
-#ifndef PARSER_H
-#define PARSER_H
+#pragma once
 
 struct AST* build_ast(char* tokensFile);
 struct Namespace* build_namespace(char* tokensFile);
-#endif

--- a/parser/test/astnodes/NamespaceTest.h
+++ b/parser/test/astnodes/NamespaceTest.h
@@ -1,9 +1,6 @@
-#ifndef NAMESPACETEST
-#define NAMESPACETEST
+#pragma once
 
 #include <stdbool.h>
 
 int namespace_test_can_parse_namespace_with_1_empty_struct();
 int namespace_test_can_parse_namespace_with_1_empty_method();
-
-#endif

--- a/parser/test/astnodes/RangeTest.h
+++ b/parser/test/astnodes/RangeTest.h
@@ -1,8 +1,5 @@
-#ifndef RANGETEST
-#define RANGETEST
+#pragma once
 
 #include <stdbool.h>
 
 void range_test1();
-
-#endif

--- a/parser/test/astnodes/StmtBlockTest.h
+++ b/parser/test/astnodes/StmtBlockTest.h
@@ -1,8 +1,5 @@
-#ifndef STMTBLOCKTEST
-#define STMTBLOCKTEST
+#pragma once
 
 #include <stdbool.h>
 
 int test_stmtblock_1();
-
-#endif

--- a/parser/test/astnodes/const/ConstValueTest.h
+++ b/parser/test/astnodes/const/ConstValueTest.h
@@ -1,5 +1,4 @@
-#ifndef CONST_VALUE_TEST_H
-#define CONST_VALUE_TEST_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -8,5 +7,3 @@ int test_boolconst_parse_bool_constant_node();
 int test_charconst_parse_char_constant_node();
 
 int test_charconst_parse_char_constant_node_newline();
-
-#endif

--- a/parser/test/astnodes/expr/ExprTest.h
+++ b/parser/test/astnodes/expr/ExprTest.h
@@ -1,5 +1,4 @@
-#ifndef EXPRTEST
-#define EXPRTEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -12,5 +11,3 @@ int expr_recognize_2_op_expr();
 int expr_test_comparison();
 
 int expr_test_3_terms();
-
-#endif

--- a/parser/test/astnodes/expr/MDirectTest.h
+++ b/parser/test/astnodes/expr/MDirectTest.h
@@ -1,8 +1,5 @@
-#ifndef SMALLDRAGON_TOPLEVEL_MDIRECTTEST_H
-#define SMALLDRAGON_TOPLEVEL_MDIRECTTEST_H
+#pragma once
 
 #include <stdbool.h>
 
 bool mdirect_test_1();
-
-#endif

--- a/parser/test/astnodes/expr/TermTest.h
+++ b/parser/test/astnodes/expr/TermTest.h
@@ -1,5 +1,4 @@
-#ifndef TERMTEST
-#define TERMTEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -8,5 +7,3 @@ int term_test_variable_term();
 
 int term_test_parentheses();
 int term_test_mdirect();
-
-#endif

--- a/parser/test/astnodes/expr/UnOpTermTest.h
+++ b/parser/test/astnodes/expr/UnOpTermTest.h
@@ -1,9 +1,6 @@
-#ifndef UNOPTERMTEST
-#define UNOPTERMTEST
+#pragma once
 
 #include <stdbool.h>
 
 int test_unop_with();
 int test_unop_without();
-
-#endif

--- a/parser/test/astnodes/statements/AssignStmtTest.h
+++ b/parser/test/astnodes/statements/AssignStmtTest.h
@@ -1,5 +1,4 @@
-#ifndef ASSIGNSTMTTEST
-#define ASSIGNSTMTTEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -15,5 +14,3 @@ int assignstmt_test_assign_char();
 int assignstmt_test_can_assign_to_struct_member();
 
 int assignstmt_test_type_declaration_for_variable();
-
-#endif

--- a/parser/test/astnodes/statements/CallTest.h
+++ b/parser/test/astnodes/statements/CallTest.h
@@ -1,5 +1,4 @@
-#ifndef METHODCALLTEST
-#define METHODCALLTEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -15,5 +14,3 @@ int methodcall_test_can_parse_subroutine_call2();
 
 int methodcall_test_can_parse_struct_member_access();
 int methodcall_test_can_parse_array_access();
-
-#endif

--- a/parser/test/astnodes/statements/CaseStmtTest.h
+++ b/parser/test/astnodes/statements/CaseStmtTest.h
@@ -1,8 +1,5 @@
-#ifndef CASESTMTTEST
-#define CASESTMTTEST
+#pragma once
 
 #include <stdbool.h>
 
 int test_parser_case_stmt();
-
-#endif

--- a/parser/test/astnodes/statements/ForStmtTest.h
+++ b/parser/test/astnodes/statements/ForStmtTest.h
@@ -1,8 +1,5 @@
-#ifndef FORSTMTTEST
-#define FORSTMTTEST
+#pragma once
 
 #include <stdbool.h>
 
 void for_test1();
-
-#endif

--- a/parser/test/astnodes/statements/IfStmtTest.h
+++ b/parser/test/astnodes/statements/IfStmtTest.h
@@ -1,9 +1,6 @@
-#ifndef IFSTMTTEST
-#define IFSTMTTEST
+#pragma once
 
 #include <stdbool.h>
 
 int if_test1();
 int if_test2();
-
-#endif

--- a/parser/test/astnodes/statements/MAssignStmtTest.h
+++ b/parser/test/astnodes/statements/MAssignStmtTest.h
@@ -1,8 +1,5 @@
-#ifndef SMALLDRAGON_TOPLEVEL_MASSIGNSTMTTEST_H
-#define SMALLDRAGON_TOPLEVEL_MASSIGNSTMTTEST_H
+#pragma once
 
 #include <stdbool.h>
 
 bool massignstmt_test1();
-
-#endif

--- a/parser/test/astnodes/statements/RetStmtTest.h
+++ b/parser/test/astnodes/statements/RetStmtTest.h
@@ -1,5 +1,4 @@
-#ifndef RETSTMTTEST
-#define RETSTMTTEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -8,5 +7,3 @@ int retstmt_test1();
 int retstmt_test2();
 
 int retstmt_test3();
-
-#endif

--- a/parser/test/astnodes/statements/StmtTest.h
+++ b/parser/test/astnodes/statements/StmtTest.h
@@ -1,10 +1,7 @@
-#ifndef STMTTEST
-#define STMTTEST
+#pragma once
 
 #include <stdbool.h>
 
 int stmt_test_assignment_statement_with_struct_access();
 
 int stmt_test_assignment_statement_with_method_call();
-
-#endif

--- a/parser/test/astnodes/statements/WhileStmtTest.h
+++ b/parser/test/astnodes/statements/WhileStmtTest.h
@@ -1,10 +1,7 @@
-#ifndef WHILESTMTTEST
-#define WHILESTMTTEST
+#pragma once
 
 #include <stdbool.h>
 
 int whilestmt_test1();
 
 int whilestmt_test2();
-
-#endif

--- a/parser/test/astnodes/struct/StructDeclTest.h
+++ b/parser/test/astnodes/struct/StructDeclTest.h
@@ -1,5 +1,4 @@
-#ifndef STRUCTDECLTEST
-#define STRUCTDECLTEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -8,5 +7,3 @@ int structdecl_test_can_parse_empty_struct_decl();
 int structdecl_test_can_parse_struct_with_1_member();
 
 int structdecl_test_can_parse_struct_with_2_members();
-
-#endif

--- a/parser/test/astnodes/struct/StructMemberTest.h
+++ b/parser/test/astnodes/struct/StructMemberTest.h
@@ -1,8 +1,5 @@
-#ifndef STRUCTMEMBERTEST
-#define STRUCTMEMBERTEST
+#pragma once
 
 #include <stdbool.h>
 
 int structmember_test_can_parse_struct_member();
-
-#endif

--- a/parser/test/astnodes/subr/DeclArgTest.h
+++ b/parser/test/astnodes/subr/DeclArgTest.h
@@ -1,8 +1,5 @@
-#ifndef DECLARGTEST
-#define DECLARGTEST
+#pragma once
 
 #include <stdbool.h>
 
 int declarg_test_parse_declared_argument();
-
-#endif

--- a/parser/test/astnodes/subr/MethodTest.h
+++ b/parser/test/astnodes/subr/MethodTest.h
@@ -1,5 +1,4 @@
-#ifndef METHODTEST
-#define METHODTEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -8,5 +7,3 @@ int method_test_can_parse_method_with_arguments();
 int method_test_can_parse_subroutine();
 
 int method_test_can_parse_method_without_arguments();
-
-#endif

--- a/parser/test/astnodes/types/BasicTypeTest.h
+++ b/parser/test/astnodes/types/BasicTypeTest.h
@@ -1,8 +1,5 @@
-#ifndef BASICTYPETEST_H
-#define BASICTYPETEST_H
+#pragma once
 
 #include <stdbool.h>
 
 int basictype_test_type_parsing_simple_type();
-
-#endif

--- a/parser/test/astnodes/types/SimpleTypeTest.h
+++ b/parser/test/astnodes/types/SimpleTypeTest.h
@@ -1,5 +1,4 @@
-#ifndef SIMPLETYPETEST
-#define SIMPLETYPETEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -10,5 +9,3 @@ int simpletype_test_typenode_parsing_fails();
 int simpletype_test_typenode_parsing_anytype();
 
 int simpletype_test_generic();
-
-#endif

--- a/parser/test/astnodes/types/StructTypeTest.h
+++ b/parser/test/astnodes/types/StructTypeTest.h
@@ -1,8 +1,5 @@
-#ifndef SMALLDRAGON_TOPLEVEL_STRUCTTYPETEST_H
-#define SMALLDRAGON_TOPLEVEL_STRUCTTYPETEST_H
+#pragma once
 
 int structtype_test();
 int structtype_test_type_param();
 int structtype_test_generic();
-
-#endif

--- a/parser/test/astnodes/types/SubrTypeTest.h
+++ b/parser/test/astnodes/types/SubrTypeTest.h
@@ -1,5 +1,4 @@
-#ifndef SUBRTYPETEST
-#define SUBRTYPETEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ int subrtype_test_typename();
 int subrtype_test_typename_subroutine_return_type();
 int subrtype_test_subroutine_type_parsing_subroutine_with_side_effects();
 int subrtype_test_subroutine_type_parsing_subroutine_without_side_effects();
-
-#endif

--- a/parser/test/astnodes/var/SimpleVarTest.h
+++ b/parser/test/astnodes/var/SimpleVarTest.h
@@ -1,5 +1,4 @@
-#ifndef SIMPLEVARTEST
-#define SIMPLEVARTEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -8,5 +7,3 @@ int simplevar_test_parse_simple_variable();
 int simplevar_test_parse_simple_indexed_variable();
 
 int simplevar_test_2_indices();
-
-#endif

--- a/parser/test/astnodes/var/VariableTest.h
+++ b/parser/test/astnodes/var/VariableTest.h
@@ -1,5 +1,4 @@
-#ifndef VARIABLETEST
-#define VARIABLETEST
+#pragma once
 
 #include <stdbool.h>
 
@@ -7,5 +6,3 @@ int variable_test_parse_struct_member_access();
 int variable_test_parse_index_access();
 int variable_test_parse_n_index_access();
 int variable_test_parse_struct_member_access_and_index_access();
-
-#endif

--- a/parser/test/test_parser_util.h
+++ b/parser/test/test_parser_util.h
@@ -1,6 +1,3 @@
-#ifndef SMALLDRAGON_TEST_PARSER_UTIL_H
-#define SMALLDRAGON_TEST_PARSER_UTIL_H
+#pragma once
 
 void status_test(char* name);
-
-#endif

--- a/rat/_struct.h
+++ b/rat/_struct.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>

--- a/tables/cc/cc.h
+++ b/tables/cc/cc.h
@@ -1,5 +1,4 @@
-#ifndef CC_H
-#define CC_H
+#pragma once
 
 #include <stdbool.h>
 #include <inttypes.h>
@@ -30,4 +29,3 @@ struct CCNode* cc_next(struct CCNode* node); //may return NULL
 char* cc_name(struct CCNode* node);
 
 void cc_set_calls_fn_ptrs(struct CC* cc, bool value);
-#endif

--- a/tables/lvst/lvst.h
+++ b/tables/lvst/lvst.h
@@ -1,5 +1,4 @@
-#ifndef LOCALVARSYMTABLE
-#define LOCALVARSYMTABLE
+#pragma once
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -88,5 +87,3 @@ uint32_t lvst_sizeof_var(struct LVST* lvst, char* name, bool x86);
 size_t lvst_nvars(struct LVST* lvst);
 // @returns    number of arguments
 size_t lvst_nargs(struct LVST* lvst);
-
-#endif

--- a/tables/sst/sst.h
+++ b/tables/sst/sst.h
@@ -1,5 +1,4 @@
-#ifndef SST_H
-#define SST_H
+#pragma once
 
 #include <stdbool.h>
 
@@ -94,5 +93,3 @@ struct SSTLine* sst_line_ctor2(
     char* _namespace);
 
 void sst_line_free(struct SSTLine* l);
-
-#endif

--- a/tables/sst/sst_fill.h
+++ b/tables/sst/sst_fill.h
@@ -1,5 +1,4 @@
-#ifndef SST_FILL_H
-#define SST_FILL_H
+#pragma once
 
 //utilities to help fill the SST
 
@@ -16,4 +15,3 @@ struct Type* method_to_type(struct Method* m);
 // @returns NULL on error
 struct SubrType* method_decl_to_subrtype(struct MethodDecl* mdecl);
 struct Type* method_decl_to_type(struct MethodDecl* mdecl);
-#endif

--- a/tables/sst/sst_print.h
+++ b/tables/sst/sst_print.h
@@ -1,8 +1,5 @@
-#ifndef SST_PRINT_H
-#define SST_PRINT_H
+#pragma once
 
 struct SST;
 
 void sst_print(struct SST* sst);
-
-#endif

--- a/tables/stst/stst.h
+++ b/tables/stst/stst.h
@@ -1,5 +1,4 @@
-#ifndef STRUCTSYMTABLE
-#define STRUCTSYMTABLE
+#pragma once
 
 #include "ast/ast.h"
 
@@ -40,5 +39,3 @@ int32_t stst_member_offset(struct STST* stst, char* struct_name, char* member_na
 uint32_t stst_size(struct STST* stst);
 
 struct STSTLine* stst_at(struct STST* stst, uint32_t index);
-
-#endif

--- a/tables/stst/stst_print.h
+++ b/tables/stst/stst_print.h
@@ -1,8 +1,5 @@
-#ifndef STST_PRINT_H
-#define STST_PRINT_H
+#pragma once
 
 struct STST;
 
 void stst_print(struct STST* stst);
-
-#endif

--- a/tables/symtable/symtable.h
+++ b/tables/symtable/symtable.h
@@ -1,5 +1,4 @@
-#ifndef SYMTABLE
-#define SYMTABLE
+#pragma once
 
 #include <stdbool.h>
 
@@ -37,5 +36,3 @@ void st_free(struct ST* st);
 
 //to memory-managed all these Types created during type inference
 void st_register_inferred_type(struct ST* st, struct Type* type);
-
-#endif

--- a/tac/tacbuffer.h
+++ b/tac/tacbuffer.h
@@ -1,5 +1,4 @@
-#ifndef SMALLDRAGON_TOPLEVEL_TACBUFFER_H
-#define SMALLDRAGON_TOPLEVEL_TACBUFFER_H
+#pragma once
 
 #include <string.h>
 #include <stdbool.h>
@@ -35,4 +34,3 @@ size_t tacbuffer_count(struct TACBuffer* buffer);
 // @returns -1 if 'tac' could not be found in 'buffer'
 // @returns index otherwise
 ssize_t tacbuffer_indexof(struct TACBuffer* buffer, struct TAC* tac);
-#endif

--- a/token/list/TokenList.h
+++ b/token/list/TokenList.h
@@ -1,5 +1,4 @@
-#ifndef TOKENLIST
-#define TOKENLIST
+#pragma once
 
 #include <stdbool.h>
 #include <inttypes.h>
@@ -40,5 +39,3 @@ char* list_rel_path(struct TokenList* list);
 
 void freeTokenList(struct TokenList* list);
 void freeTokenListShallow(struct TokenList* list);
-
-#endif

--- a/token/token/token.h
+++ b/token/token/token.h
@@ -1,5 +1,4 @@
-#ifndef TOKEN
-#define TOKEN
+#pragma once
 
 #include <string.h>
 #include <stdbool.h>
@@ -36,5 +35,3 @@ struct Token* makeToken2(int kind, char* value);
 struct Token* makeTokenStringConst(char* value);
 
 void freeToken(struct Token* token);
-
-#endif


### PR DESCRIPTION
this is replaced by
```
 #pragma once
```

All headers should now use
 #pragma once
instead of old-style header guards.