### PR TITLE
compiler: do not emit dead code

### DIFF
--- a/compiler/main/analyzer/dead/dead_analyzer.h
+++ b/compiler/main/analyzer/dead/dead_analyzer.h
@@ -6,7 +6,9 @@
  * are assumed to be live.
  */
 
-struct ST;
+#include "compiler/main/util/ctx.h"
+
 struct AST;
 
-void analyze_dead_code(struct ST* st, struct AST* ast);
+// @returns false on error
+bool analyze_dead_code(struct Ctx* ctx, struct AST* ast);

--- a/compiler/main/cli/flags/all_flags.c
+++ b/compiler/main/cli/flags/all_flags.c
@@ -20,6 +20,13 @@ struct Flag all_flags[] = {
 	.is_set = false,
     },
     {
+	.name = "debug-dead",
+	.description = "debug dead code analysis",
+	.has_arg = false,
+	.arg_default_value = NULL,
+	.is_set = false,
+    },
+    {
 	.name = "version",
 	.description = "display version text",
 	.has_arg = false,

--- a/compiler/main/cli/flags/flags.c
+++ b/compiler/main/cli/flags/flags.c
@@ -416,6 +416,9 @@ char* flags_filenames(struct Flags* flags, int index) {
 bool flags_debug(struct Flags* flags) {
 	return flags_set(flags, "debug");
 }
+bool flags_debug_dead(struct Flags* flags) {
+	return flags_set(flags, "debug-dead");
+}
 bool flags_version(struct Flags* flags) {
 	return flags_set(flags, "version");
 }

--- a/compiler/main/cli/flags/flags.h
+++ b/compiler/main/cli/flags/flags.h
@@ -21,6 +21,7 @@ int flags_count_filenames(struct Flags* flags);
 char* flags_filenames(struct Flags* flags, int index);
 
 bool flags_debug(struct Flags* flags);
+bool flags_debug_dead(struct Flags* flags);
 bool flags_version(struct Flags* flags);
 bool flags_help(struct Flags* flags);
 bool flags_x86(struct Flags* flags);

--- a/compiler/main/compiler.c
+++ b/compiler/main/compiler.c
@@ -128,8 +128,15 @@ bool compile(struct Flags* flags) {
 		printf("[debug] running analyzers...\n");
 	}
 
+	bool success;
+
 	analyze_functions(ctx_tables(ctx), ast);
-	analyze_dead_code(ctx_tables(ctx), ast);
+	success = analyze_dead_code(ctx, ast);
+
+	if (!success) {
+		return false;
+	}
+
 	analyze_termination(ctx_tables(ctx));
 	analyze_annotations(ctx_tables(ctx), ast);
 	analyze_data(ctx_tables(ctx), ast);
@@ -140,7 +147,6 @@ bool compile(struct Flags* flags) {
 		printf("\n");
 	}
 
-	bool success;
 	if (flags_x86(flags)) {
 		success = compile_and_write_x86(ast, ctx);
 	} else {

--- a/compiler/main/x86_code_gen/cg_x86_single_function.c
+++ b/compiler/main/x86_code_gen/cg_x86_single_function.c
@@ -42,6 +42,11 @@ bool compile_and_write_x86_single_function(struct Method* m, struct Ctx* ctx, st
 
 	struct SSTLine* line = sst_get(st->sst, current_function_name);
 
+	if (!line) {
+		success = false;
+		goto exit_name;
+	}
+
 	if (line->dead != DEAD_ISLIVE) {
 
 		if (flags_debug_dead(ctx_flags(ctx))) {

--- a/compiler/main/x86_code_gen/cg_x86_single_function.c
+++ b/compiler/main/x86_code_gen/cg_x86_single_function.c
@@ -33,6 +33,24 @@ bool compile_and_write_x86_single_function(struct Method* m, struct Ctx* ctx, st
 	struct TACBuffer* buffer = tacbuffer_ctor();
 	struct ST* st = ctx_tables(ctx);
 
+	char* current_function_name = m->decl->name;
+
+	if (current_function_name == NULL) {
+		success = false;
+		goto exit_name;
+	}
+
+	struct SSTLine* line = sst_get(st->sst, current_function_name);
+
+	if (line->dead != DEAD_ISLIVE) {
+
+		if (flags_debug_dead(ctx_flags(ctx))) {
+			printf("[debug][dead-code]: skip %s\n", current_function_name);
+		}
+
+		return true;
+	}
+
 	//populate ctx->st->lvst
 	lvst_clear(st->lvst);
 	lvst_fill(m, st);
@@ -79,13 +97,6 @@ bool compile_and_write_x86_single_function(struct Method* m, struct Ctx* ctx, st
 		goto exit;
 	}
 
-	char* current_function_name = m->decl->name;
-
-	if (current_function_name == NULL) {
-		success = false;
-		goto exit;
-	}
-
 	if (flags_debug(ctx_flags(ctx))) {
 
 		printf("RAT for function '%s'\n", m->decl->name);
@@ -103,6 +114,6 @@ exit:
 exit_tacbuffer:
 
 	tacbuffer_dtor(buffer);
-
+exit_name:
 	return success;
 }


### PR DESCRIPTION
Since dead code analysis seems to be working for all examples, there is no need anymore to emit all functions.

Add flag '-debug-dead' to enable debug output for dead code analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line debugging option for dead code analysis.
	- Added functionality to check for a new "debug-dead" flag to enhance debugging capabilities.
- **Bug Fixes**
	- Enhanced error handling during code compilation so that issues in dead code analysis now reliably halt the process and provide clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->