### PR TITLE
typechecker: check for return statement

### DIFF
--- a/compiler/main/typechecker/_tc.h
+++ b/compiler/main/typechecker/_tc.h
@@ -25,9 +25,10 @@ bool tc_local_var_decl_stmt(struct LocalVarDeclStmt* a, struct TCCtx* tcctx);
 
 bool tc_methodcall(struct Call* m, struct TCCtx* tcctx);
 
-bool tc_stmt(struct Stmt* s, struct TCCtx* tcctx);
+bool tc_stmt(struct Stmt* s, struct TCCtx* tcctx, bool must_return);
+bool tc_stmt_must_return(struct Stmt* s, struct TCCtx* tcctx);
 
-bool tc_ifstmt(struct IfStmt* i, struct TCCtx* tcctx);
+bool tc_ifstmt(struct IfStmt* i, struct TCCtx* tcctx, bool must_return);
 bool tc_whilestmt(struct WhileStmt* w, struct TCCtx* tcctx);
 bool tc_retstmt(struct RetStmt* r, struct TCCtx* tcctx);
 bool tc_forstmt(struct ForStmt* f, struct TCCtx* tcctx);
@@ -47,4 +48,4 @@ bool tc_method(struct Method* m, struct TCCtx* tcctx);
 
 bool tc_namespace(struct Namespace* n, struct TCCtx* tcctx);
 
-bool tc_stmtblock(struct StmtBlock* s, struct TCCtx* tcctx);
+bool tc_stmtblock(struct StmtBlock* s, struct TCCtx* tcctx, bool must_return);

--- a/compiler/main/typechecker/tc_forstmt.c
+++ b/compiler/main/typechecker/tc_forstmt.c
@@ -25,7 +25,7 @@ bool tc_forstmt(struct ForStmt* f, struct TCCtx* tcctx) {
 	if (!tc_range(f->range, tcctx)) { return false; }
 
 	tcctx->depth_inside_loop++;
-	bool is_ok = tc_stmtblock(f->block, tcctx);
+	bool is_ok = tc_stmtblock(f->block, tcctx, false);
 	tcctx->depth_inside_loop--;
 
 	return is_ok;

--- a/compiler/main/typechecker/tc_ifstmt.c
+++ b/compiler/main/typechecker/tc_ifstmt.c
@@ -14,7 +14,7 @@
 #include "typechecker/util/tc_utils.h"
 #include "tcctx.h"
 
-bool tc_ifstmt(struct IfStmt* i, struct TCCtx* tcctx) {
+bool tc_ifstmt(struct IfStmt* i, struct TCCtx* tcctx, bool must_return) {
 
 	if (tcctx->debug) {
 		printf("[debug] typecheck if stmt\n");
@@ -46,10 +46,10 @@ bool tc_ifstmt(struct IfStmt* i, struct TCCtx* tcctx) {
 		return false;
 	}
 
-	bool success = tc_stmtblock(i->block, tcctx);
+	bool success = tc_stmtblock(i->block, tcctx, must_return);
 
 	if (i->else_block != NULL) {
-		success &= tc_stmtblock(i->else_block, tcctx);
+		success &= tc_stmtblock(i->else_block, tcctx, must_return);
 	}
 
 	return success;

--- a/compiler/main/typechecker/tc_method.c
+++ b/compiler/main/typechecker/tc_method.c
@@ -27,5 +27,5 @@ bool tc_method(struct Method* m, struct TCCtx* tcctx) {
 	lvst_clear(tcctx->st->lvst);
 	lvst_fill(m, tcctx->st);
 
-	return tc_stmtblock(m->block, tcctx);
+	return tc_stmtblock(m->block, tcctx, true);
 }

--- a/compiler/main/typechecker/tc_stmts.c
+++ b/compiler/main/typechecker/tc_stmts.c
@@ -12,8 +12,33 @@
 #include "typechecker/util/tc_utils.h"
 #include "tcctx.h"
 #include <stdio.h>
+#include <stdlib.h>
 
-bool tc_stmt(struct Stmt* s, struct TCCtx* tcctx) {
+bool tc_stmt_must_return(struct Stmt* s, struct TCCtx* tcctx) {
+
+	switch (s->kind) {
+
+		case 3: return tc_ifstmt(s->ptr.m3, tcctx, true);
+		case 4: return tc_retstmt(s->ptr.m4, tcctx);
+		case 1:
+		case 2:
+		case 5:
+		case 7:
+		case 10:
+		case 99: {
+			char* snippet = str_stmt(s);
+			error_snippet_and_msg(tcctx, snippet, "should return here", TC_ERR_MUST_RETURN);
+			free(snippet);
+			return false;
+		}
+
+		default:
+			// invalid stmt
+			return false;
+	}
+}
+
+bool tc_stmt(struct Stmt* s, struct TCCtx* tcctx, bool must_return) {
 
 	tcctx->current_line_num = s->super.line_num;
 
@@ -21,11 +46,15 @@ bool tc_stmt(struct Stmt* s, struct TCCtx* tcctx) {
 		printf("[debug] typecheck statement line %d\n", tcctx->current_line_num);
 	}
 
+	if (must_return) {
+		return tc_stmt_must_return(s, tcctx);
+	}
+
 	switch (s->kind) {
 
 		case 1: return tc_methodcall(s->ptr.m1, tcctx);
 		case 2: return tc_whilestmt(s->ptr.m2, tcctx);
-		case 3: return tc_ifstmt(s->ptr.m3, tcctx);
+		case 3: return tc_ifstmt(s->ptr.m3, tcctx, false);
 		case 4: return tc_retstmt(s->ptr.m4, tcctx);
 		case 5: return tc_assignstmt(s->ptr.m5, tcctx);
 		case 7: return tc_forstmt(s->ptr.m7, tcctx);

--- a/compiler/main/typechecker/tc_whilestmt.c
+++ b/compiler/main/typechecker/tc_whilestmt.c
@@ -41,7 +41,7 @@ bool tc_whilestmt(struct WhileStmt* w, struct TCCtx* tcctx) {
 	}
 
 	tcctx->depth_inside_loop++;
-	bool has_err = tc_stmtblock(w->block, tcctx);
+	bool has_err = tc_stmtblock(w->block, tcctx, false);
 	tcctx->depth_inside_loop--;
 
 	return has_err;

--- a/compiler/main/typechecker/tcctx.h
+++ b/compiler/main/typechecker/tcctx.h
@@ -13,6 +13,9 @@ enum TC_ERR_KIND {
 
 	TC_ERR_WRONG_RETURN_TYPE,
 
+	// function should return here, but does not
+	TC_ERR_MUST_RETURN,
+
 	TC_ERR_BINOP_TYPE_MISMATCH,
 
 	TC_ERR_SUBR_NOT_FOUND,

--- a/compiler/main/typechecker/typecheck.c
+++ b/compiler/main/typechecker/typecheck.c
@@ -70,13 +70,15 @@ bool tc_namespace(struct Namespace* n, struct TCCtx* tcctx) {
 	return has_err;
 }
 
-bool tc_stmtblock(struct StmtBlock* s, struct TCCtx* tcctx) {
+bool tc_stmtblock(struct StmtBlock* s, struct TCCtx* tcctx, bool must_return) {
 
 	tcctx->current_line_num = s->super.line_num;
 
 	bool has_err = false;
 	for (uint16_t i = 0; i < s->count; i++) {
-		has_err |= tc_stmt(s->stmts[i], tcctx);
+
+		const bool last = i == (s->count - 1);
+		has_err |= tc_stmt(s->stmts[i], tcctx, last && must_return);
 	}
 	return has_err;
 }

--- a/compiler/test/testcases.c
+++ b/compiler/test/testcases.c
@@ -286,6 +286,7 @@ void (*tests_typechecker[])() = {
     test_typecheck_too_many_indices,
     test_typecheck_local_var_not_a_subroutine,
     test_typecheck_var_not_found,
+    test_typecheck_no_return_stmt,
 
     //one test to trigger all typechecker errors, in sequence,
     //to iterate on the error messages (better dev experience)

--- a/compiler/test/typechecker/test-src/no_return_stmt.dg
+++ b/compiler/test/typechecker/test-src/no_return_stmt.dg
@@ -1,0 +1,8 @@
+fn main () -> int {
+
+	uint8 x = 3;
+
+	if x == 3 {
+		x = 2;
+	}
+}

--- a/compiler/test/typechecker/test_typechecker.c
+++ b/compiler/test/typechecker/test_typechecker.c
@@ -201,6 +201,20 @@ void test_typecheck_var_not_found() {
 	free_tc_errors(errors);
 }
 
+void test_typecheck_no_return_stmt() {
+
+	status_test_typechecker("typecheck return stmt not found");
+	char* filename = "compiler/test/typechecker/test-src/no_return_stmt.dg";
+
+	struct TCError* errors = typecheck_file(filename);
+
+	assert(errors != NULL);
+	assert(errors->err_kind == TC_ERR_MUST_RETURN);
+	assert(errors->next == NULL);
+
+	free_tc_errors(errors);
+}
+
 void test_typecheck_all_type_errors() {
 
 	status_test_typechecker("typecheck all type errors");

--- a/compiler/test/typechecker/test_typechecker.h
+++ b/compiler/test/typechecker/test_typechecker.h
@@ -13,4 +13,5 @@ void test_typecheck_wrong_op_unop();
 void test_typecheck_too_many_indices();
 void test_typecheck_local_var_not_a_subroutine();
 void test_typecheck_var_not_found();
+void test_typecheck_no_return_stmt();
 void test_typecheck_all_type_errors();

--- a/examples/other/everything.dg
+++ b/examples/other/everything.dg
@@ -34,6 +34,8 @@ fn main () ~> int {
 
 	sub1();
 	sub2();
+
+	return 0;
 }
 
 fn sub2 () -> int {

--- a/examples/typeinference/localvartypeinference.dg
+++ b/examples/typeinference/localvartypeinference.dg
@@ -8,6 +8,7 @@ fn main () ~> int {
 	b = a12 + 4 + subr();
 	subr();
 
+	return 0;
 }
 
 fn subr() -> int {


### PR DESCRIPTION
Prevent rip from falling off the end of the function :)

Also implement a testcase for this.

resolves #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced type checking to enforce explicit return statements where necessary, resulting in clearer error messaging when functions or blocks lack a required return.
  
- **Tests**
  - Expanded the test suite to cover scenarios with missing return statements, ensuring robust type-check verification.
  
- **Examples**
  - Updated demonstration code to include explicit return values, aligning with the improved return validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->