### PR TITLE
ast: refactor struct Stmt

### DIFF
--- a/ast/ast/ast_stmts.h
+++ b/ast/ast/ast_stmts.h
@@ -39,26 +39,35 @@ struct LocalVarDeclStmt {
 	struct Type* type;
 	char* name;
 };
+
+enum STMT_KIND {
+	STMT_KIND_CALL,
+	STMT_KIND_WHILE,
+	STMT_KIND_IF,
+	STMT_KIND_RETURN,
+	STMT_KIND_ASSIGN,
+	STMT_KIND_FOR,
+
+	STMT_KIND_LOCAL_VAR_DECL,
+
+	STMT_KIND_BREAK,
+	STMT_KIND_CONTINUE,
+};
+
 struct Stmt {
 	struct ASTNode super;
 
 	//only one of those will be present, 'kind' tells us
 	union myptr {
-		struct Call* m1;
-		struct WhileStmt* m2;
-		struct IfStmt* m3;
-		struct RetStmt* m4;
-		struct AssignStmt* m5;
-		struct ForStmt* m7;
-		struct SwitchStmt* m8;
-		struct LocalVarDeclStmt* m10;
+		struct Call* call;
+		struct WhileStmt* while_stmt;
+		struct IfStmt* if_stmt;
+		struct RetStmt* return_stmt;
+		struct AssignStmt* assign_stmt;
+		struct ForStmt* for_stmt;
+		struct LocalVarDeclStmt* local_var_decl_stmt;
 	} ptr;
-	uint8_t kind; //0-based
-
-	//if one of these is true,
-	//=> kind == 99
-	bool is_continue;
-	bool is_break;
+	enum STMT_KIND kind;
 };
 struct WhileStmt {
 	struct ASTNode super;

--- a/ast/util/copy_ast.c
+++ b/ast/util/copy_ast.c
@@ -305,15 +305,20 @@ struct Stmt* copy_stmt(struct Stmt* stmt) {
 
 	res->kind = stmt->kind;
 	switch (stmt->kind) {
-		case 1: res->ptr.m1 = copy_call(stmt->ptr.m1); break;
-		case 2: res->ptr.m2 = copy_while_stmt(stmt->ptr.m2); break;
-		case 3: res->ptr.m3 = copy_if_stmt(stmt->ptr.m3); break;
-		case 4: res->ptr.m4 = copy_ret_stmt(stmt->ptr.m4); break;
-		case 5: res->ptr.m5 = copy_assign_stmt(stmt->ptr.m5); break;
-		case 7: res->ptr.m7 = copy_for_stmt(stmt->ptr.m7); break;
-		default:
-			res->is_break = stmt->is_break;
-			res->is_continue = stmt->is_continue;
+		case STMT_KIND_CALL: res->ptr.call = copy_call(stmt->ptr.call); break;
+		case STMT_KIND_WHILE: res->ptr.while_stmt = copy_while_stmt(stmt->ptr.while_stmt); break;
+		case STMT_KIND_IF: res->ptr.if_stmt = copy_if_stmt(stmt->ptr.if_stmt); break;
+		case STMT_KIND_RETURN: res->ptr.return_stmt = copy_ret_stmt(stmt->ptr.return_stmt); break;
+		case STMT_KIND_ASSIGN: res->ptr.assign_stmt = copy_assign_stmt(stmt->ptr.assign_stmt); break;
+		case STMT_KIND_FOR: res->ptr.for_stmt = copy_for_stmt(stmt->ptr.for_stmt); break;
+		case STMT_KIND_LOCAL_VAR_DECL:
+			res->ptr.local_var_decl_stmt = copy_local_var_decl_stmt(stmt->ptr.local_var_decl_stmt);
+			break;
+		case STMT_KIND_BREAK:
+			res->kind = STMT_KIND_BREAK;
+			break;
+		case STMT_KIND_CONTINUE:
+			res->kind = STMT_KIND_CONTINUE;
 			break;
 	}
 
@@ -386,6 +391,22 @@ struct ForStmt* copy_for_stmt(struct ForStmt* f) {
 	asprintf(&(res->index_name), "%s", f->index_name);
 	res->range = copy_range(f->range);
 	res->block = copy_stmt_block(f->block);
+
+	return res;
+}
+
+struct LocalVarDeclStmt* copy_local_var_decl_stmt(struct LocalVarDeclStmt* l) {
+
+	struct LocalVarDeclStmt* res = make(LocalVarDeclStmt);
+	if (!res) {
+		return NULL;
+	}
+
+	res->super.line_num = l->super.line_num;
+	res->super.annotations = l->super.annotations;
+
+	res->type = copy_type(l->type);
+	asprintf(&(res->name), "%s", l->name);
 
 	return res;
 }

--- a/ast/util/copy_ast.h
+++ b/ast/util/copy_ast.h
@@ -21,6 +21,7 @@ struct RetStmt* copy_ret_stmt(struct RetStmt* r);
 struct Stmt* copy_stmt(struct Stmt* stmt);
 struct WhileStmt* copy_while_stmt(struct WhileStmt* w);
 struct ForStmt* copy_for_stmt(struct ForStmt* f);
+struct LocalVarDeclStmt* copy_local_var_decl_stmt(struct LocalVarDeclStmt* l);
 
 //c_types_util
 struct Type* copy_type(struct Type* t);

--- a/ast/util/free_ast.c
+++ b/ast/util/free_ast.c
@@ -215,27 +215,30 @@ bool free_stmt(struct Stmt* s) {
 
 	switch (s->kind) {
 
-		case 99: /* nothing to do here */ break;
-		case 1:
-			free_call(s->ptr.m1);
+		case STMT_KIND_BREAK:
+		case STMT_KIND_CONTINUE:
+			// nothing to do here
 			break;
-		case 2:
-			free_while_stmt(s->ptr.m2);
+		case STMT_KIND_CALL:
+			free_call(s->ptr.call);
 			break;
-		case 3:
-			free_if_stmt(s->ptr.m3);
+		case STMT_KIND_WHILE:
+			free_while_stmt(s->ptr.while_stmt);
 			break;
-		case 4:
-			free_ret_stmt(s->ptr.m4);
+		case STMT_KIND_IF:
+			free_if_stmt(s->ptr.if_stmt);
 			break;
-		case 5:
-			free_assign_stmt(s->ptr.m5);
+		case STMT_KIND_RETURN:
+			free_ret_stmt(s->ptr.return_stmt);
 			break;
-		case 7:
-			free_for_stmt(s->ptr.m7);
+		case STMT_KIND_ASSIGN:
+			free_assign_stmt(s->ptr.assign_stmt);
 			break;
-		case 10:
-			free_local_var_decl_stmt(s->ptr.m10);
+		case STMT_KIND_FOR:
+			free_for_stmt(s->ptr.for_stmt);
+			break;
+		case STMT_KIND_LOCAL_VAR_DECL:
+			free_local_var_decl_stmt(s->ptr.local_var_decl_stmt);
 			break;
 		default:
 			fprintf(stderr, "Error in free_stmt: unhandled: %d\n", s->kind);

--- a/ast/util/str_ast.c
+++ b/ast/util/str_ast.c
@@ -658,22 +658,22 @@ char* str_stmt(struct Stmt* stmt) {
 
 	switch (stmt->kind) {
 
-		case 1: return str_call(stmt->ptr.m1);
-		case 2: return str_while_stmt(stmt->ptr.m2);
-		case 3: return str_if_stmt(stmt->ptr.m3);
-		case 4: return str_ret_stmt(stmt->ptr.m4);
-		case 5: return str_assign_stmt(stmt->ptr.m5);
-		case 7: return str_for_stmt(stmt->ptr.m7);
-		case 99: {
-			//break,continue,throw,...
+		case STMT_KIND_CALL: return str_call(stmt->ptr.call);
+		case STMT_KIND_WHILE: return str_while_stmt(stmt->ptr.while_stmt);
+		case STMT_KIND_IF: return str_if_stmt(stmt->ptr.if_stmt);
+		case STMT_KIND_RETURN: return str_ret_stmt(stmt->ptr.return_stmt);
+		case STMT_KIND_ASSIGN: return str_assign_stmt(stmt->ptr.assign_stmt);
+		case STMT_KIND_FOR: return str_for_stmt(stmt->ptr.for_stmt);
+		case STMT_KIND_BREAK:
+		case STMT_KIND_CONTINUE: {
 			char* res = malloc(sizeof(char) * 30);
 			if (!res) {
 				return NULL;
 			}
 			strcpy(res, "");
 
-			if (stmt->is_break) { sprintf(res, "break"); }
-			if (stmt->is_continue) { sprintf(res, "continue"); }
+			if (stmt->kind == STMT_KIND_BREAK) { sprintf(res, "break"); }
+			if (stmt->kind == STMT_KIND_CONTINUE) { sprintf(res, "continue"); }
 			return res;
 		}
 

--- a/ast/visitor/visitor.c
+++ b/ast/visitor/visitor.c
@@ -150,26 +150,27 @@ static bool visit_stmt(struct Stmt* s, VISITOR, void* arg) {
 
 	switch (s->kind) {
 
-		case 1:
-			return visit_call(s->ptr.m1, visitor, arg);
-		case 2:
-			return visit_while_stmt(s->ptr.m2, visitor, arg);
-		case 3:
-			return visit_if_stmt(s->ptr.m3, visitor, arg);
-		case 4:
-			return visit_ret_stmt(s->ptr.m4, visitor, arg);
-		case 5:
-			return visit_assign_stmt(s->ptr.m5, visitor, arg);
-		case 7:
-			return visit_for_stmt(s->ptr.m7, visitor, arg);
-		case 10:
-			visit_local_var_decl_stmt(s->ptr.m10, visitor, arg);
+		case STMT_KIND_CALL:
+			return visit_call(s->ptr.call, visitor, arg);
+		case STMT_KIND_WHILE:
+			return visit_while_stmt(s->ptr.while_stmt, visitor, arg);
+		case STMT_KIND_IF:
+			return visit_if_stmt(s->ptr.if_stmt, visitor, arg);
+		case STMT_KIND_RETURN:
+			return visit_ret_stmt(s->ptr.return_stmt, visitor, arg);
+		case STMT_KIND_ASSIGN:
+			return visit_assign_stmt(s->ptr.assign_stmt, visitor, arg);
+		case STMT_KIND_FOR:
+			return visit_for_stmt(s->ptr.for_stmt, visitor, arg);
+		case STMT_KIND_LOCAL_VAR_DECL:
+			visit_local_var_decl_stmt(s->ptr.local_var_decl_stmt, visitor, arg);
 			break;
-		case 99:
-			if (s->is_break) { visit_break_stmt(visitor, arg); }
-			if (s->is_continue) { visit_continue_stmt(visitor, arg); }
+		case STMT_KIND_BREAK:
+			visit_break_stmt(visitor, arg);
 			break;
-
+		case STMT_KIND_CONTINUE:
+			visit_continue_stmt(visitor, arg);
+			break;
 		default:
 			fprintf(stderr, "[Visitor] Fatal error in %s: kind == %d\n", __func__, s->kind);
 			return false;

--- a/compiler/main/gen_tac/gen_tac.h
+++ b/compiler/main/gen_tac/gen_tac.h
@@ -30,8 +30,6 @@ bool tac_deref(struct TACBuffer* buffer, struct Deref* d, struct Ctx* ctx);
 // @returns false on error
 bool tac_forstmt(struct TACBuffer* buffer, struct ForStmt* f, struct Ctx* ctx);
 
-void tac_switchstmt(struct TACBuffer* buffer, struct SwitchStmt* ss, struct Ctx* ctx);
-
 void tac_method(struct TACBuffer* buffer, struct Method* m, struct Ctx* ctx);
 
 void tac_stmtblock(struct TACBuffer* buffer, struct StmtBlock* block, struct Ctx* ctx);

--- a/compiler/main/gen_tac/gen_tac_stmt.c
+++ b/compiler/main/gen_tac/gen_tac_stmt.c
@@ -10,7 +10,7 @@ bool tac_stmt(struct TACBuffer* buffer, struct Stmt* stmt, struct Ctx* ctx) {
 		printf("[debug] %s: line %d\n", __func__, stmt->super.line_num);
 	}
 
-	if (stmt->is_break) {
+	if (stmt->kind == STMT_KIND_BREAK) {
 		const int32_t label_loop_end = ctx_get_label_loop_end(ctx);
 		if (label_loop_end < 0) {
 			return false;
@@ -18,7 +18,7 @@ bool tac_stmt(struct TACBuffer* buffer, struct Stmt* stmt, struct Ctx* ctx) {
 		tacbuffer_append(buffer, makeTACGoto(label_loop_end));
 		return true;
 	}
-	if (stmt->is_continue) {
+	if (stmt->kind == STMT_KIND_CONTINUE) {
 		const int32_t label_loop_start = ctx_get_label_loop_start(ctx);
 		if (label_loop_start < 0) {
 			return false;
@@ -28,14 +28,14 @@ bool tac_stmt(struct TACBuffer* buffer, struct Stmt* stmt, struct Ctx* ctx) {
 	}
 
 	switch (stmt->kind) {
-		case 1: return tac_call(buffer, stmt->ptr.m1, ctx); break;
-		case 2: return tac_whilestmt(buffer, stmt->ptr.m2, ctx); break;
-		case 3: tac_ifstmt(buffer, stmt->ptr.m3, ctx); break;
-		case 4: tac_retstmt(buffer, stmt->ptr.m4, ctx); break;
-		case 5: tac_assignstmt(buffer, stmt->ptr.m5, ctx); break;
-		case 7: return tac_forstmt(buffer, stmt->ptr.m7, ctx); break;
+		case STMT_KIND_CALL: return tac_call(buffer, stmt->ptr.call, ctx); break;
+		case STMT_KIND_WHILE: return tac_whilestmt(buffer, stmt->ptr.while_stmt, ctx); break;
+		case STMT_KIND_IF: tac_ifstmt(buffer, stmt->ptr.if_stmt, ctx); break;
+		case STMT_KIND_RETURN: tac_retstmt(buffer, stmt->ptr.return_stmt, ctx); break;
+		case STMT_KIND_ASSIGN: tac_assignstmt(buffer, stmt->ptr.assign_stmt, ctx); break;
+		case STMT_KIND_FOR: return tac_forstmt(buffer, stmt->ptr.for_stmt, ctx); break;
 
-		case 10:
+		case STMT_KIND_LOCAL_VAR_DECL:
 			// local var declaration stmt, needs no code gen
 			break;
 

--- a/compiler/main/typechecker/tc_stmts.c
+++ b/compiler/main/typechecker/tc_stmts.c
@@ -18,14 +18,15 @@ bool tc_stmt_must_return(struct Stmt* s, struct TCCtx* tcctx) {
 
 	switch (s->kind) {
 
-		case 3: return tc_ifstmt(s->ptr.m3, tcctx, true);
-		case 4: return tc_retstmt(s->ptr.m4, tcctx);
-		case 1:
-		case 2:
-		case 5:
-		case 7:
-		case 10:
-		case 99: {
+		case STMT_KIND_IF: return tc_ifstmt(s->ptr.if_stmt, tcctx, true);
+		case STMT_KIND_RETURN: return tc_retstmt(s->ptr.return_stmt, tcctx);
+		case STMT_KIND_CALL:
+		case STMT_KIND_WHILE:
+		case STMT_KIND_ASSIGN:
+		case STMT_KIND_FOR:
+		case STMT_KIND_LOCAL_VAR_DECL:
+		case STMT_KIND_BREAK:
+		case STMT_KIND_CONTINUE: {
 			char* snippet = str_stmt(s);
 			error_snippet_and_msg(tcctx, snippet, "should return here", TC_ERR_MUST_RETURN);
 			free(snippet);
@@ -52,17 +53,16 @@ bool tc_stmt(struct Stmt* s, struct TCCtx* tcctx, bool must_return) {
 
 	switch (s->kind) {
 
-		case 1: return tc_methodcall(s->ptr.m1, tcctx);
-		case 2: return tc_whilestmt(s->ptr.m2, tcctx);
-		case 3: return tc_ifstmt(s->ptr.m3, tcctx, false);
-		case 4: return tc_retstmt(s->ptr.m4, tcctx);
-		case 5: return tc_assignstmt(s->ptr.m5, tcctx);
-		case 7: return tc_forstmt(s->ptr.m7, tcctx);
-		case 10: return tc_local_var_decl_stmt(s->ptr.m10, tcctx);
-
-		case 99:
-			if (s->is_continue) {}
-			if (s->is_break) {}
+		case STMT_KIND_CALL: return tc_methodcall(s->ptr.call, tcctx);
+		case STMT_KIND_WHILE: return tc_whilestmt(s->ptr.while_stmt, tcctx);
+		case STMT_KIND_IF: return tc_ifstmt(s->ptr.if_stmt, tcctx, false);
+		case STMT_KIND_RETURN: return tc_retstmt(s->ptr.return_stmt, tcctx);
+		case STMT_KIND_ASSIGN: return tc_assignstmt(s->ptr.assign_stmt, tcctx);
+		case STMT_KIND_FOR: return tc_forstmt(s->ptr.for_stmt, tcctx);
+		case STMT_KIND_LOCAL_VAR_DECL: return tc_local_var_decl_stmt(s->ptr.local_var_decl_stmt, tcctx);
+		case STMT_KIND_BREAK:
+		case STMT_KIND_CONTINUE:
+			return true;
 
 		default:
 			// invalid stmt

--- a/compiler/test/typeinference/test_typeinference_util.c
+++ b/compiler/test/typeinference/test_typeinference_util.c
@@ -69,9 +69,9 @@ struct Type* typeinfer_in_file(char* filename) {
 
 	struct Stmt* stmt = m->block->stmts[m->block->count - 1];
 	assert(stmt != NULL);
-	assert(stmt->kind == 4);
+	assert(stmt->kind == STMT_KIND_RETURN);
 
-	struct Expr* expr = stmt->ptr.m4->return_value;
+	struct Expr* expr = stmt->ptr.return_stmt->return_value;
 	struct Type* returned_type = infer_type_expr(ctx_tables(ctx), expr);
 
 	struct Type* copy = copy_type(returned_type);


### PR DESCRIPTION
Define enum STMT_KIND instead of hardcoding stmt->kind values.

Makes the code more readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling and copying of local variable declarations.

- **Refactor**
	- Streamlined internal processing of code statements by replacing ambiguous identifiers with descriptive markers.
	- Simplified control flow management for break and continue statements, leading to clearer error notifications and more robust execution.

- **Removed**
	- Deprecated functionality related to legacy switch statement handling has been eliminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->