### PR TITLE
ast: refactor struct Term

### DIFF
--- a/ast/ast/ast_expr.h
+++ b/ast/ast/ast_expr.h
@@ -70,18 +70,29 @@ struct UnOpTerm {
 	// may be NULL
 	struct Term* term;
 };
+
+enum TERM_KIND {
+
+	TERM_KIND_CALL,
+	TERM_KIND_EXPR,
+	TERM_KIND_VAR,
+	TERM_KIND_STRINGCONST,
+	TERM_KIND_CONSTVALUE,
+};
+
 struct Term {
 	struct ASTNode super;
+
 	//only one of these is present,
 	//check 'kind' for which it is.
 	union myptr2 {
 
-		struct Call* m4;
-		struct Expr* m5;
-		struct Variable* m6;
-		struct StringConst* m8;
-		struct ConstValue* m12;
+		struct Call* call_term;
+		struct Expr* expr_term;
+		struct Variable* var_term;
+		struct StringConst* stringconst_term;
+		struct ConstValue* constvalue_term;
 	} ptr;
 
-	uint8_t kind; // 4 .. 12
+	enum TERM_KIND kind;
 };

--- a/ast/test/test_str_ast.c
+++ b/ast/test/test_str_ast.c
@@ -88,8 +88,8 @@ void test_ast_str_expr() {
 	struct ConstValue cv = {.ptr.m2_int_const = 45, .kind = 2};
 
 	struct Term b = {
-	    .kind = 12,
-	    .ptr.m12 = &cv};
+	    .kind = TERM_KIND_CONSTVALUE,
+	    .ptr.constvalue_term = &cv};
 
 	struct UnOpTerm u = {
 	    .op = OP_MINUS,
@@ -126,8 +126,8 @@ void test_ast_str_unopterm() {
 	struct ConstValue cv = {.ptr.m2_int_const = 3489, .kind = 2};
 
 	struct Term b = {
-	    .kind = 12,
-	    .ptr.m12 = &cv};
+	    .kind = TERM_KIND_CONSTVALUE,
+	    .ptr.constvalue_term = &cv};
 
 	struct UnOpTerm u = {
 	    .op = OP_MINUS,
@@ -146,8 +146,8 @@ void test_ast_str_term() {
 	struct ConstValue cv = {.ptr.m2_int_const = 3489, .kind = 2};
 
 	struct Term b = {
-	    .kind = 12,
-	    .ptr.m12 = &cv};
+	    .kind = TERM_KIND_CONSTVALUE,
+	    .ptr.constvalue_term = &cv};
 
 	char* s = str_term(&b);
 

--- a/ast/util/copy_ast.c
+++ b/ast/util/copy_ast.c
@@ -93,11 +93,11 @@ struct Term* copy_term(struct Term* t) {
 
 	switch (t->kind) {
 
-		case 4: res->ptr.m4 = copy_call(t->ptr.m4); break;
-		case 5: res->ptr.m5 = copy_expr(t->ptr.m5); break;
-		case 6: res->ptr.m6 = copy_variable(t->ptr.m6); break;
-		case 8: res->ptr.m8 = copy_string_const(t->ptr.m8); break;
-		case 12: res->ptr.m12 = copy_const_value(t->ptr.m12); break;
+		case TERM_KIND_CALL: res->ptr.call_term = copy_call(t->ptr.call_term); break;
+		case TERM_KIND_EXPR: res->ptr.expr_term = copy_expr(t->ptr.expr_term); break;
+		case TERM_KIND_VAR: res->ptr.var_term = copy_variable(t->ptr.var_term); break;
+		case TERM_KIND_STRINGCONST: res->ptr.stringconst_term = copy_string_const(t->ptr.stringconst_term); break;
+		case TERM_KIND_CONSTVALUE: res->ptr.constvalue_term = copy_const_value(t->ptr.constvalue_term); break;
 		default:
 			fprintf(stderr, "[AST][Error] copy_term(...), kind was: %d\n", t->kind);
 			return NULL;

--- a/ast/util/free_ast.c
+++ b/ast/util/free_ast.c
@@ -119,11 +119,11 @@ void free_struct_member(struct StructMember* sm) {
 bool free_term(struct Term* t) {
 
 	switch (t->kind) {
-		case 4: free_call(t->ptr.m4); break;
-		case 5: free_expr(t->ptr.m5); break;
-		case 6: free_variable(t->ptr.m6); break;
-		case 8: free_string_const(t->ptr.m8); break;
-		case 12: free_const_value(t->ptr.m12); break;
+		case TERM_KIND_CALL: free_call(t->ptr.call_term); break;
+		case TERM_KIND_EXPR: free_expr(t->ptr.expr_term); break;
+		case TERM_KIND_VAR: free_variable(t->ptr.var_term); break;
+		case TERM_KIND_STRINGCONST: free_string_const(t->ptr.stringconst_term); break;
+		case TERM_KIND_CONSTVALUE: free_const_value(t->ptr.constvalue_term); break;
 		default:
 			fprintf(stderr, "Error in free_term(...)\n");
 			free(t);

--- a/ast/util/str_ast.c
+++ b/ast/util/str_ast.c
@@ -633,11 +633,11 @@ char* str_deref(struct Deref* d) {
 char* str_term(struct Term* t) {
 
 	switch (t->kind) {
-		case 4: return str_call(t->ptr.m4);
-		case 5: return str_expr(t->ptr.m5);
-		case 6: return str_variable(t->ptr.m6);
-		case 8: return str_string_const(t->ptr.m8);
-		case 12: return str_const_value(t->ptr.m12);
+		case TERM_KIND_CALL: return str_call(t->ptr.call_term);
+		case TERM_KIND_EXPR: return str_expr(t->ptr.expr_term);
+		case TERM_KIND_VAR: return str_variable(t->ptr.var_term);
+		case TERM_KIND_STRINGCONST: return str_string_const(t->ptr.stringconst_term);
+		case TERM_KIND_CONSTVALUE: return str_const_value(t->ptr.constvalue_term);
 	}
 
 	error("str_term");

--- a/ast/visitor/visitor.c
+++ b/ast/visitor/visitor.c
@@ -334,17 +334,17 @@ static bool visit_term(struct Term* t, VISITOR, void* arg) {
 	visitor(t, NODE_TERM, arg);
 
 	switch (t->kind) {
-		case 4:
-			return visit_call(t->ptr.m4, visitor, arg);
-		case 5:
-			return visit_expr(t->ptr.m5, visitor, arg);
-		case 6:
-			return visit_variable(t->ptr.m6, visitor, arg);
-		case 8:
-			visit_string_const(t->ptr.m8, visitor, arg);
+		case TERM_KIND_CALL:
+			return visit_call(t->ptr.call_term, visitor, arg);
+		case TERM_KIND_EXPR:
+			return visit_expr(t->ptr.expr_term, visitor, arg);
+		case TERM_KIND_VAR:
+			return visit_variable(t->ptr.var_term, visitor, arg);
+		case TERM_KIND_STRINGCONST:
+			visit_string_const(t->ptr.stringconst_term, visitor, arg);
 			break;
-		case 12:
-			visit_const_value(t->ptr.m12, visitor, arg);
+		case TERM_KIND_CONSTVALUE:
+			visit_const_value(t->ptr.constvalue_term, visitor, arg);
 			break;
 		default:
 			fprintf(stderr, "[Visitor][Error] Fatal(2)\n");

--- a/compiler/main/gen_tac/gen_tac_term.c
+++ b/compiler/main/gen_tac/gen_tac_term.c
@@ -7,16 +7,11 @@
 bool tac_term(struct TACBuffer* buffer, struct Term* t, struct Ctx* ctx) {
 
 	switch (t->kind) {
-		case 4: tac_call(buffer, t->ptr.m4, ctx); break;
-		case 5: tac_expr(buffer, t->ptr.m5, ctx); break;
-		case 6: tac_variable(buffer, t->ptr.m6, ctx); break;
-		case 8: return tac_const_data(buffer, t->ptr.m8, ctx);
-		case 11:
-			fprintf(stderr, "Fatal Error. Lambdas should not exist at this stage.\n");
-			return false;
-			//lambdas should not exist anymore at this stage,
-			//having been converted into named functions
-		case 12: tac_constvalue(buffer, t->ptr.m12); break;
+		case TERM_KIND_CALL: tac_call(buffer, t->ptr.call_term, ctx); break;
+		case TERM_KIND_EXPR: tac_expr(buffer, t->ptr.expr_term, ctx); break;
+		case TERM_KIND_VAR: tac_variable(buffer, t->ptr.var_term, ctx); break;
+		case TERM_KIND_STRINGCONST: return tac_const_data(buffer, t->ptr.stringconst_term, ctx);
+		case TERM_KIND_CONSTVALUE: tac_constvalue(buffer, t->ptr.constvalue_term); break;
 		default:
 			fprintf(stderr, "%s: unsupported: %d\n", __func__, t->kind);
 			return false;
@@ -31,8 +26,8 @@ bool tac_term_addr(struct TACBuffer* buffer, struct Term* t, struct Ctx* ctx) {
 	uint8_t width;
 
 	switch (t->kind) {
-		case 5: tac_expr_addr(buffer, t->ptr.m5, ctx); break;
-		case 6: tac_variable_addr(buffer, t->ptr.m6, ctx, &width); break;
+		case TERM_KIND_EXPR: tac_expr_addr(buffer, t->ptr.expr_term, ctx); break;
+		case TERM_KIND_VAR: tac_variable_addr(buffer, t->ptr.var_term, ctx, &width); break;
 		default:
 			fprintf(stderr, "%s: unsupported: %d\n", __func__, t->kind);
 			return false;

--- a/compiler/main/gen_tac/gen_tac_whilestmt.c
+++ b/compiler/main/gen_tac/gen_tac_whilestmt.c
@@ -19,12 +19,12 @@ bool tac_whilestmt(struct TACBuffer* buffer, struct WhileStmt* w, struct Ctx* ct
 		struct UnOpTerm* u = e->term1;
 		if (u->op == OP_NONE) {
 			struct Term* t = u->term;
-			if (t->kind == 12) {
+			if (t->kind == TERM_KIND_CONSTVALUE) {
 				//const value, "while my_const { ... }"
 				//and the const ist known at compile time so we can
 				//just decide if we emit infinite loop or skip this block
 
-				struct ConstValue* c = t->ptr.m12;
+				struct ConstValue* c = t->ptr.constvalue_term;
 				bool inf = false;
 
 				switch (c->kind) {

--- a/compiler/main/typechecker/tc_assignstmt.c
+++ b/compiler/main/typechecker/tc_assignstmt.c
@@ -47,8 +47,8 @@ bool tc_assignstmt(struct AssignStmt* a, struct TCCtx* tcctx) {
 	} else {
 		assert(a->lvalue->deref);
 		struct Term* term = a->lvalue->deref->term;
-		assert(term->kind == 6);
-		name = term->ptr.m6->simple_var->name;
+		assert(term->kind == TERM_KIND_VAR);
+		name = term->ptr.var_term->simple_var->name;
 	}
 
 	struct LVSTLine* line = lvst_get(tcctx->st->lvst, name);

--- a/compiler/main/typechecker/tc_term.c
+++ b/compiler/main/typechecker/tc_term.c
@@ -27,14 +27,17 @@ bool tc_term(struct Term* term, struct TCCtx* tcctx) {
 
 	switch (term->kind) {
 
-		case 4: return tc_methodcall(term->ptr.m4, tcctx);
-		case 5: return tc_expr(term->ptr.m5, tcctx);
-		case 6: return tc_var(term->ptr.m6, tcctx);
+		case TERM_KIND_CALL: return tc_methodcall(term->ptr.call_term, tcctx);
+		case TERM_KIND_EXPR: return tc_expr(term->ptr.expr_term, tcctx);
+		case TERM_KIND_VAR: return tc_var(term->ptr.var_term, tcctx);
 
-		case 8: return true; //stringconst
+		case TERM_KIND_STRINGCONST: return true;
 
-		case 11: return true; //lambdas are already handled at this point
-		case 12: return tc_constvalue(term->ptr.m12);
+		case TERM_KIND_CONSTVALUE: return tc_constvalue(term->ptr.constvalue_term);
+
+		default:
+			fprintf(stderr, "%s:%s: unhandled case: %d\n", __FILE__, __func__, term->kind);
+			return false;
 	}
 	return true;
 }

--- a/compiler/main/typeinference/typeinfer_term.c
+++ b/compiler/main/typeinference/typeinfer_term.c
@@ -29,16 +29,11 @@ struct Type* infer_type_term(struct ST* st, struct Term* t) {
 
 	switch (t->kind) {
 
-		case 4: return infer_type_methodcall(st, t->ptr.m4);
-		case 5: return infer_type_expr(st, t->ptr.m5);
-		case 6: return infer_type_variable(st, t->ptr.m6);
-		case 8: return typeFromStrArray(st, "char");
-		case 11:
-			printf("cannot infer type of lambda");
-			printf("[Typeinference][Error] Fatal. (in typeinfer_term.c).\n");
-			return NULL;
-
-		case 12: return infer_type_constvalue(st, t->ptr.m12);
+		case TERM_KIND_CALL: return infer_type_methodcall(st, t->ptr.call_term);
+		case TERM_KIND_EXPR: return infer_type_expr(st, t->ptr.expr_term);
+		case TERM_KIND_VAR: return infer_type_variable(st, t->ptr.var_term);
+		case TERM_KIND_STRINGCONST: return typeFromStrArray(st, "char");
+		case TERM_KIND_CONSTVALUE: return infer_type_constvalue(st, t->ptr.constvalue_term);
 
 		default:
 			fprintf(stderr, "[Typeinference][Error] Fatal. (in typeinfer_term.c).\n");

--- a/parser/main/astnodes/expr/Term.c
+++ b/parser/main/astnodes/expr/Term.c
@@ -34,8 +34,8 @@ struct Term* makeTerm_other(struct Expr* expr) {
 	res->super.line_num = expr->super.line_num;
 	res->super.annotations = expr->super.annotations;
 
-	res->kind = 5;
-	res->ptr.m5 = expr;
+	res->kind = TERM_KIND_EXPR;
+	res->ptr.expr_term = expr;
 	return res;
 }
 
@@ -74,18 +74,18 @@ struct Term* makeTerm(struct TokenList* tokens) {
 
 other_term:
 
-	if ((res->ptr.m12 = makeConstValue(copy)) != NULL) {
-		res->kind = 12;
+	if ((res->ptr.constvalue_term = makeConstValue(copy)) != NULL) {
+		res->kind = TERM_KIND_CONSTVALUE;
 		goto end;
 	}
 
-	if ((res->ptr.m4 = makeCall(copy)) != NULL) {
-		res->kind = 4;
+	if ((res->ptr.call_term = makeCall(copy)) != NULL) {
+		res->kind = TERM_KIND_CALL;
 		goto end;
 	}
 
-	if ((res->ptr.m6 = makeVariable(copy)) != NULL) {
-		res->kind = 6;
+	if ((res->ptr.var_term = makeVariable(copy)) != NULL) {
+		res->kind = TERM_KIND_VAR;
 		goto end;
 	}
 exit_error:
@@ -105,7 +105,7 @@ struct Term* initTerm() {
 	struct Term* res = make(Term);
 
 	res->kind = 0;
-	res->ptr.m5 = NULL;
+	res->ptr.expr_term = NULL;
 
 	return res;
 }
@@ -114,9 +114,9 @@ static bool tryInitExpr(struct Term* res, struct TokenList* copy) {
 
 	list_consume(copy, 1);
 
-	res->kind = 5;
-	res->ptr.m5 = makeExpr(copy);
-	if (res->ptr.m5 == NULL) {
+	res->kind = TERM_KIND_EXPR;
+	res->ptr.expr_term = makeExpr(copy);
+	if (res->ptr.expr_term == NULL) {
 		free(res);
 		freeTokenListShallow(copy);
 		printf("expected an Expression, but got :");
@@ -136,9 +136,9 @@ static bool tryInitExpr(struct Term* res, struct TokenList* copy) {
 
 static bool tryInitStringConst(struct Term* res, struct TokenList* copy) {
 
-	res->kind = 8;
-	res->ptr.m8 = makeStringConst(copy);
-	if (res->ptr.m8 == NULL) {
+	res->kind = TERM_KIND_STRINGCONST;
+	res->ptr.stringconst_term = makeStringConst(copy);
+	if (res->ptr.stringconst_term == NULL) {
 
 		printf("expected an String, but got :");
 		list_print(copy);

--- a/parser/main/astnodes/statements/AssignStmt.c
+++ b/parser/main/astnodes/statements/AssignStmt.c
@@ -103,8 +103,8 @@ static struct UnOpTerm* convert_left(struct LValue* lv) {
 
 		struct Term* myterm1 = make(Term);
 		myterm1->super = myvar->super;
-		myterm1->kind = 6;
-		myterm1->ptr.m6 = myvar;
+		myterm1->kind = TERM_KIND_VAR;
+		myterm1->ptr.var_term = myvar;
 
 		struct UnOpTerm* uop1 = make(UnOpTerm);
 		uop1->super = myvar->super;
@@ -132,8 +132,8 @@ static struct UnOpTerm* convert_right(struct Expr* expr) {
 
 	struct Term* myterm2 = make(Term);
 	myterm2->super = expr->super;
-	myterm2->kind = 5;
-	myterm2->ptr.m5 = expr;
+	myterm2->kind = TERM_KIND_EXPR;
+	myterm2->ptr.expr_term = expr;
 
 	uop2->op = OP_NONE;
 	uop2->term = myterm2;

--- a/parser/test/astnodes/expr/ExprTest.c
+++ b/parser/test/astnodes/expr/ExprTest.c
@@ -23,7 +23,7 @@ int expr_test_simple_expression() {
 
 	assert(expr != NULL);
 	assert(expr->term1 != NULL);
-	assert(expr->term1->term->ptr.m12->ptr.m2_int_const == 4);
+	assert(expr->term1->term->ptr.constvalue_term->ptr.m2_int_const == 4);
 
 	freeTokenList(list);
 	free_expr(expr);
@@ -41,11 +41,11 @@ int expr_test_variable_name_expression() {
 	struct Expr* expr = makeExpr(list);
 
 	assert(expr != NULL);
-	assert(expr->term1->term->ptr.m6 != NULL);
-	assert(expr->term1->term->ptr.m6->simple_var != NULL);
+	assert(expr->term1->term->ptr.var_term != NULL);
+	assert(expr->term1->term->ptr.var_term->simple_var != NULL);
 	assert(
 	    strcmp(
-		expr->term1->term->ptr.m6->simple_var->name,
+		expr->term1->term->ptr.var_term->simple_var->name,
 		"x") == 0);
 
 	freeTokenList(list);
@@ -103,12 +103,12 @@ int expr_test_comparison() {
 
 	//assert about the terms
 
-	struct Variable* v = term1->ptr.m6;
+	struct Variable* v = term1->ptr.var_term;
 	assert(v != NULL);
 
-	assert(term2->ptr.m12->kind == 2);
+	assert(term2->ptr.constvalue_term->kind == 2);
 
-	assert(term2->ptr.m12->ptr.m2_int_const == 5);
+	assert(term2->ptr.constvalue_term->ptr.m2_int_const == 5);
 
 	struct SimpleVar* sv = v->simple_var;
 	assert(sv != NULL);

--- a/parser/test/astnodes/expr/TermTest.c
+++ b/parser/test/astnodes/expr/TermTest.c
@@ -41,7 +41,7 @@ int term_test_variable_term() {
 
 	assert(list_size(list) == 0);
 
-	struct Variable* v = t->ptr.m6;
+	struct Variable* v = t->ptr.var_term;
 	assert(v != NULL);
 
 	struct SimpleVar* sv = v->simple_var;
@@ -67,12 +67,12 @@ int term_test_parentheses() {
 	struct Term* t = makeTerm(list);
 	assert(t != NULL);
 
-	struct Expr* expr = t->ptr.m5;
+	struct Expr* expr = t->ptr.expr_term;
 	assert(expr != NULL);
 
 	assert(list_size(list) == 0);
 
-	struct Variable* v = expr->term1->term->ptr.m6;
+	struct Variable* v = expr->term1->term->ptr.var_term;
 	assert(v != NULL);
 
 	struct SimpleVar* sv = v->simple_var;

--- a/parser/test/astnodes/statements/CallTest.c
+++ b/parser/test/astnodes/statements/CallTest.c
@@ -180,7 +180,7 @@ int methodcall_test_can_parse_array_access() {
 
 	struct Expr* expr = call->callable->simple_var->indices[0];
 
-	assert(strcmp(expr->term1->term->ptr.m6->simple_var->name, "y") == 0);
+	assert(strcmp(expr->term1->term->ptr.var_term->simple_var->name, "y") == 0);
 
 	freeTokenList(tokens);
 	free_call(call);

--- a/parser/test/astnodes/var/SimpleVarTest.c
+++ b/parser/test/astnodes/var/SimpleVarTest.c
@@ -54,7 +54,7 @@ int simplevar_test_parse_simple_indexed_variable() {
 
 	assert(
 	    1 ==
-	    (node->indices[0]->term1->term->ptr.m12->ptr.m2_int_const));
+	    (node->indices[0]->term1->term->ptr.constvalue_term->ptr.m2_int_const));
 
 	freeTokenList(list);
 	free_simple_var(node);


### PR DESCRIPTION
Define enum TERM_KIND instead of hardcoding term->kind values.

Makes the code more readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

In this release, we’ve made several internal improvements that enhance overall reliability and maintainability. The handling of various term types has been standardized using clear, descriptive identifiers, resulting in more consistent error reporting. Additionally, automated tests have been updated to validate these changes and ensure robustness.

- **Refactor**
  - Standardized term categorization by replacing ambiguous numeric values with descriptive identifiers for improved clarity and error handling.
- **Tests**
  - Updated test cases to align with the new term structure, ensuring increased consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->